### PR TITLE
Simplify parser code

### DIFF
--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -139,7 +139,7 @@ object Parser {
       }
 
     val strMoves: P0[(InitialPosition, List[San], Option[String])] =
-      ((commentary.rep0 ~ strMove.rep) ~ (result <* whitespaces).? <* commentary.rep0).map {
+      ((commentary.rep0 ~ strMove.rep0) ~ (result <* whitespaces).? <* commentary.rep0).map {
         case ((coms, sans), res) => (InitialPosition(cleanComments(coms)), sans.toList, res)
       }
   }

--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -35,7 +35,7 @@ object Parser {
       init         = parsedMoves._1
       sans         = Sans(parsedMoves._2)
       resultOption = parsedMoves._3
-      tags         = resultOption.filterNot(_ => preTags.exists(_.Result)).foldLeft(preTags)(_ + _)
+      tags         = resultOption.filterNot(_ => preTags.exists(_.Result)).foldLeft(preTags)(_ + Tag(_.Result, _))
     } yield ParsedPgn(init, tags, sans)
   }
 
@@ -51,18 +51,10 @@ object Parser {
 
     private def cleanComments(comments: List[String]) = comments.map(_.trim).filter(_.nonEmpty)
 
-    def apply(pgn: String): Validated[String, (InitialPosition, List[San], Option[Tag])] =
+    def apply(pgn: String): Validated[String, (InitialPosition, List[San], Option[String])] =
       strMoves.parse(pgn) match {
-        case Right((_, (init, moves, result))) =>
-          valid(
-            (
-              init,
-              moves,
-              result map { r =>
-                Tag(_.Result, r)
-              }
-            )
-          )
+        case Right((_, parsedResult)) =>
+          valid(parsedResult)
         case Left(err) =>
           err match {
             case P.Error(0, _) => valid((InitialPosition(List()), List(), None))

--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -24,9 +24,6 @@ object Parser {
       .mkString("\n")
       .replace("[pgn]", "")
       .replace("[/pgn]", "")
-      //.replace("‑", "-")
-      //.replace("–", "-")
-      .replace("e.p.", "") // silly en-passant notation
     parse(preprocessed)
   }
 
@@ -146,14 +143,10 @@ object Parser {
     val fileMap = rangeToMap('a' to 'h')
     val rankMap = rangeToMap('1' to '8')
 
-    val castleQSide = List("O-O-O", "o-o-o", "0-0-0",
-      "O‑O‑O", "o‑o‑o", "0‑0‑0",
-      "O–O–O", "o–o–o", "0–0–0")
+    val castleQSide      = List("O-O-O", "o-o-o", "0-0-0", "O‑O‑O", "o‑o‑o", "0‑0‑0", "O–O–O", "o–o–o", "0–0–0")
     val qCastle: P[Side] = P.stringIn(castleQSide).as(QueenSide)
 
-    val castleKSide = List("O-O", "o-o", "0-0",
-      "O‑O", "o‑o", "0‑0",
-      "O–O", "o–o", "0–0")
+    val castleKSide = List("O-O", "o-o", "0-0", "O‑O", "o‑o", "0‑0", "O–O", "o–o", "0–0")
 
     val kCastle: P[Side] = P.stringIn(castleKSide).as(KingSide)
 
@@ -186,7 +179,7 @@ object Parser {
     val promotion: P[PromotableRole] = P.char('=').?.with1 *> mapParserChar(promotable, "promotion")
 
     // e5
-    val pawn: P[Std] = dest.map(Std(_, Pawn))
+    val pawn: P[Std] = dest.map(Std(_, Pawn)) <* (R.wsp.rep0.soft ~ P.string("e.p.")).?
 
     // Bg5
     val ambigous: P[Std] = (role ~ x ~ dest).map { case ((ro, ca), de) =>

--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -65,17 +65,6 @@ object Parser {
 
     private def cleanComments(comments: List[String]) = comments.map(_.trim).filter(_.nonEmpty)
 
-    def apply(pgn: String): Validated[String, (InitialPosition, List[San], Option[String])] =
-      strMoves.parse(pgn) match {
-        case Right((_, parsedResult)) =>
-          valid(parsedResult)
-        case Left(err) =>
-          err match {
-            case P.Error(0, _) => valid((InitialPosition(List()), List(), None))
-            case _             => invalid(showExpectations("Cannot parse moves", pgn, err))
-          }
-      }
-
     def moves(str: String): Validated[String, Sans] =
       strMove.rep.map(xs => Sans(xs.toList)).parse(str) match {
         case Right((_, str)) =>
@@ -223,12 +212,6 @@ object Parser {
     val moveWithSuffix: P[San] = (move ~ suffixes <* whitespaces)
       .map { case (std, suf) =>
         std withSuffixes suf
-      }
-
-    def apply(str: String): Validated[String, San] =
-      moveWithSuffix.parse(str) match {
-        case Right((_, san)) => valid(san)
-        case Left(err)       => invalid(showExpectations("Cannot parse move", str, err))
       }
 
     def mapParser[A](pairs: Iterable[(String, A)], name: String): P[A] = {

--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -24,8 +24,8 @@ object Parser {
       .mkString("\n")
       .replace("[pgn]", "")
       .replace("[/pgn]", "")
-      .replace("‑", "-")
-      .replace("–", "-")
+      //.replace("‑", "-")
+      //.replace("–", "-")
       .replace("e.p.", "") // silly en-passant notation
     parse(preprocessed)
   }
@@ -146,9 +146,16 @@ object Parser {
     val fileMap = rangeToMap('a' to 'h')
     val rankMap = rangeToMap('1' to '8')
 
-    val qCastle: P[Side] = P.stringIn(List("O-O-O", "o-o-o", "0-0-0")).as(QueenSide)
+    val castleQSide = List("O-O-O", "o-o-o", "0-0-0",
+      "O‑O‑O", "o‑o‑o", "0‑0‑0",
+      "O–O–O", "o–o–o", "0–0–0")
+    val qCastle: P[Side] = P.stringIn(castleQSide).as(QueenSide)
 
-    val kCastle: P[Side] = P.stringIn(List("O-O", "o-o", "0-0")).as(KingSide)
+    val castleKSide = List("O-O", "o-o", "0-0",
+      "O‑O", "o‑o", "0‑0",
+      "O–O", "o–o", "0–0")
+
+    val kCastle: P[Side] = P.stringIn(castleKSide).as(KingSide)
 
     val glyph: P[Glyph] =
       mapParser(

--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -249,11 +249,6 @@ object Parser {
         case Right((_, tags)) => valid(tags)
       }
 
-    def fromFullPgn(pgn: String): Validated[String, Tags] =
-      splitTagAndMoves(pgn) flatMap { case (tags, _) =>
-        apply(tags)
-      }
-
   }
 
   // there must be a newline between the tags and the first move

--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -17,7 +17,6 @@ object Parser {
 
   def full(pgn: String): Validated[String, ParsedPgn] = {
     val preprocessed = augmentString(pgn).linesIterator
-      .map(_.trim)
       .filterNot {
         _.headOption.contains('%')
       }

--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -21,11 +21,10 @@ object Parser {
         _.headOption.contains('%')
       }
       .mkString("\n")
-      .replace("[pgn]", "")
-      .replace("[/pgn]", "")
     parse(preprocessed)
   }
 
+  // todo simplify the mapping logic
   private lazy val fullParser: P0[ParsedPgn] =
     ((whitespaces *> TagParser.tags.?) ~ MovesParser.strMoves.?).map {
       case (oTags, o) => {
@@ -42,8 +41,11 @@ object Parser {
       }
     }
 
-  def parse(pgn: String): Validated[String, ParsedPgn] =
-    fullParser.parse(pgn) match {
+  private lazy val fullParserWithOptionalTag =
+    whitespaces *> P.string("[pgn]").? *> fullParser <* P.string("[/pgn]").? <* whitespaces
+
+  private def parse(pgn: String): Validated[String, ParsedPgn] =
+    fullParserWithOptionalTag.parse(pgn) match {
       case Right((_, parsedResult)) =>
         valid(parsedResult)
       case Left(err) =>

--- a/src/main/scala/format/pgn/Parser.scala
+++ b/src/main/scala/format/pgn/Parser.scala
@@ -30,17 +30,20 @@ object Parser {
     parse(preprocessed)
   }
 
-  lazy val fullParser: P0[ParsedPgn] = ((whitespaces *> TagParser.tags.?) ~ MovesParser.strMoves.?).map { case (oTags, o) => {
+  lazy val fullParser: P0[ParsedPgn] = ((whitespaces *> TagParser.tags.?) ~ MovesParser.strMoves.?).map {
+    case (oTags, o) => {
       val preTags = Tags(oTags.map(_.toList).getOrElse(List()))
       o match {
         case None => ParsedPgn(InitialPosition(List()), preTags, Sans(List()))
         case Some((init, sans, resultOption)) => {
-          val tags = resultOption.filterNot(_ => preTags.exists(_.Result)).foldLeft(preTags)(_ + Tag(_.Result, _))
+          val tags =
+            resultOption.filterNot(_ => preTags.exists(_.Result)).foldLeft(preTags)(_ + Tag(_.Result, _))
           ParsedPgn(init, tags, Sans(sans))
         }
       }
 
-  }}
+    }
+  }
 
   def parse(pgn: String): Validated[String, ParsedPgn] =
     fullParser.parse(pgn) match {
@@ -242,13 +245,13 @@ object Parser {
 
   object TagParser {
 
-    val tagName: P[String]   = R.alpha.rep.string.withContext("Tag name can only contains alphabet characters")
-    val escaped: P[String]   = P.char('\\') *> (R.dquote | P.char('\\')).string
-    val valueChar: P[String] = escaped | P.charWhere(_ != '"').string
-    val tagValue: P[String]  = valueChar.rep0.map(_.mkString).with1.surroundedBy(R.dquote)
-    val tagContent: P[Tag]   = ((tagName <* R.wsp.rep) ~ tagValue).map(p => Tag(p._1, p._2))
-    val tag: P[Tag]          = tagContent.between(P.char('['), P.char(']')) <* whitespace.rep0
-    val tags: P[NonEmptyList[Tag]]       = tag.rep
+    val tagName: P[String]         = R.alpha.rep.string.withContext("Tag name can only contains alphabet characters")
+    val escaped: P[String]         = P.char('\\') *> (R.dquote | P.char('\\')).string
+    val valueChar: P[String]       = escaped | P.charWhere(_ != '"').string
+    val tagValue: P[String]        = valueChar.rep0.map(_.mkString).with1.surroundedBy(R.dquote)
+    val tagContent: P[Tag]         = ((tagName <* R.wsp.rep) ~ tagValue).map(p => Tag(p._1, p._2))
+    val tag: P[Tag]                = tagContent.between(P.char('['), P.char(']')) <* whitespace.rep0
+    val tags: P[NonEmptyList[Tag]] = tag.rep
 
   }
 

--- a/src/test/scala/format/pgn/ParserTest.scala
+++ b/src/test/scala/format/pgn/ParserTest.scala
@@ -3,8 +3,6 @@ package format.pgn
 
 import cats.syntax.option._
 
-import chess.variant.Standard
-
 class ParserTest extends ChessTest {
 
   import Fixtures._
@@ -12,45 +10,45 @@ class ParserTest extends ChessTest {
   val parser                 = Parser.full _
   def parseMove(str: String) = Parser.MoveParser(str)
 
-  "promotion check" should {
-    "as a queen" in {
-      parser("b8=Q ") must beValid.like { case a =>
-        a.sans.value.headOption must beSome.like { case san: Std =>
-          san.promotion must_== Option(Queen)
-        }
-      }
-    }
-    "as a rook" in {
-      parser("b8=R ") must beValid.like { case a =>
-        a.sans.value.headOption must beSome.like { case san: Std =>
-          san.promotion must_== Option(Rook)
-        }
-      }
-    }
-  }
+  //"promotion check" should {
+    //"as a queen" in {
+      //parser("b8=Q ") must beValid.like { case a =>
+        //a.sans.value.headOption must beSome.like { case san: Std =>
+          //san.promotion must_== Option(Queen)
+        //}
+      //}
+    //}
+    //"as a rook" in {
+      //parser("b8=R ") must beValid.like { case a =>
+        //a.sans.value.headOption must beSome.like { case san: Std =>
+          //san.promotion must_== Option(Rook)
+        //}
+      //}
+    //}
+  //}
 
-  "result" in {
-    "no tag but inline result" in {
-      parser(noTagButResult) must beValid.like { case parsed =>
-        parsed.tags("Result") must_== Option("1-0")
-      }
-    }
-    "in tags" in {
-      parser(whiteResignsInTags) must beValid.like { case parsed =>
-        parsed.tags("Result") must_== Option("0-1")
-      }
-    }
-    "in moves" in {
-      parser(whiteResignsInMoves) must beValid.like { case parsed =>
-        parsed.tags("Result") must_== Option("0-1")
-      }
-    }
-    "in tags and moves" in {
-      parser(whiteResignsInTagsAndMoves) must beValid.like { case parsed =>
-        parsed.tags("Result") must_== Option("0-1")
-      }
-    }
-  }
+  //"result" in {
+    //"no tag but inline result" in {
+      //parser(noTagButResult) must beValid.like { case parsed =>
+        //parsed.tags("Result") must_== Option("1-0")
+      //}
+    //}
+    //"in tags" in {
+      //parser(whiteResignsInTags) must beValid.like { case parsed =>
+        //parsed.tags("Result") must_== Option("0-1")
+      //}
+    //}
+    //"in moves" in {
+      //parser(whiteResignsInMoves) must beValid.like { case parsed =>
+        //parsed.tags("Result") must_== Option("0-1")
+      //}
+    //}
+    //"in tags and moves" in {
+      //parser(whiteResignsInTagsAndMoves) must beValid.like { case parsed =>
+        //parsed.tags("Result") must_== Option("0-1")
+      //}
+    //}
+  //}
 
   "glyphs" in {
     parseMove("e4") must beValid.like { case a =>

--- a/src/test/scala/format/pgn/ParserTest.scala
+++ b/src/test/scala/format/pgn/ParserTest.scala
@@ -7,8 +7,8 @@ class ParserTest extends ChessTest {
 
   import Fixtures._
 
-  val parser                 = Parser.full _
-  def parseMove(str: String) = Parser.MoveParser(str)
+  val parser                  = Parser.full _
+  def parseMove(str: String)  = Parser.MoveParser(str)
   def parseMoves(str: String) = Parser.MovesParser(str)
 
   "promotion check" should {

--- a/src/test/scala/format/pgn/ParserTest.scala
+++ b/src/test/scala/format/pgn/ParserTest.scala
@@ -7,9 +7,8 @@ class ParserTest extends ChessTest {
 
   import Fixtures._
 
-  val parser                  = Parser.full _
-  def parseMove(str: String)  = Parser.MoveParser(str)
-  def parseMoves(str: String) = Parser.MovesParser(str)
+  val parser    = Parser.full _
+  val parseMove = Parser.MovesParser.move _
 
   "promotion check" should {
     "as a queen" in {

--- a/src/test/scala/format/pgn/ParserTest.scala
+++ b/src/test/scala/format/pgn/ParserTest.scala
@@ -8,7 +8,7 @@ class ParserTest extends ChessTest {
   import Fixtures._
 
   val parser    = Parser.full _
-  val parseMove = Parser.MovesParser.move _
+  val parseMove = Parser.move _
 
   "promotion check" should {
     "as a queen" in {

--- a/src/test/scala/format/pgn/ParserTest.scala
+++ b/src/test/scala/format/pgn/ParserTest.scala
@@ -9,46 +9,47 @@ class ParserTest extends ChessTest {
 
   val parser                 = Parser.full _
   def parseMove(str: String) = Parser.MoveParser(str)
+  def parseMoves(str: String) = Parser.MovesParser(str)
 
-  //"promotion check" should {
-    //"as a queen" in {
-      //parser("b8=Q ") must beValid.like { case a =>
-        //a.sans.value.headOption must beSome.like { case san: Std =>
-          //san.promotion must_== Option(Queen)
-        //}
-      //}
-    //}
-    //"as a rook" in {
-      //parser("b8=R ") must beValid.like { case a =>
-        //a.sans.value.headOption must beSome.like { case san: Std =>
-          //san.promotion must_== Option(Rook)
-        //}
-      //}
-    //}
-  //}
+  "promotion check" should {
+    "as a queen" in {
+      parser("b8=Q ") must beValid.like { case a =>
+        a.sans.value.headOption must beSome.like { case san: Std =>
+          san.promotion must_== Option(Queen)
+        }
+      }
+    }
+    "as a rook" in {
+      parser("b8=R ") must beValid.like { case a =>
+        a.sans.value.headOption must beSome.like { case san: Std =>
+          san.promotion must_== Option(Rook)
+        }
+      }
+    }
+  }
 
-  //"result" in {
-    //"no tag but inline result" in {
-      //parser(noTagButResult) must beValid.like { case parsed =>
-        //parsed.tags("Result") must_== Option("1-0")
-      //}
-    //}
-    //"in tags" in {
-      //parser(whiteResignsInTags) must beValid.like { case parsed =>
-        //parsed.tags("Result") must_== Option("0-1")
-      //}
-    //}
-    //"in moves" in {
-      //parser(whiteResignsInMoves) must beValid.like { case parsed =>
-        //parsed.tags("Result") must_== Option("0-1")
-      //}
-    //}
-    //"in tags and moves" in {
-      //parser(whiteResignsInTagsAndMoves) must beValid.like { case parsed =>
-        //parsed.tags("Result") must_== Option("0-1")
-      //}
-    //}
-  //}
+  "result" in {
+    "no tag but inline result" in {
+      parser(noTagButResult) must beValid.like { case parsed =>
+        parsed.tags("Result") must_== Option("1-0")
+      }
+    }
+    "in tags" in {
+      parser(whiteResignsInTags) must beValid.like { case parsed =>
+        parsed.tags("Result") must_== Option("0-1")
+      }
+    }
+    "in moves" in {
+      parser(whiteResignsInMoves) must beValid.like { case parsed =>
+        parsed.tags("Result") must_== Option("0-1")
+      }
+    }
+    "in tags and moves" in {
+      parser(whiteResignsInTagsAndMoves) must beValid.like { case parsed =>
+        parsed.tags("Result") must_== Option("0-1")
+      }
+    }
+  }
 
   "glyphs" in {
     parseMove("e4") must beValid.like { case a =>

--- a/src/test/scala/format/pgn/ParserTest.scala
+++ b/src/test/scala/format/pgn/ParserTest.scala
@@ -278,8 +278,8 @@ class ParserTest extends ChessTest {
     }
   }
   "overflow 3: tags" in {
-    Parser.TagParser.fromFullPgn(overflow3) must beValid.like { case tags =>
-      tags.value.size must_== 9
+    parser(overflow3) must beValid.like { case a =>
+      a.tags.value.size must_== 9
     }
   }
   "chessbase arrows" in {


### PR DESCRIPTION
Close #255 also improve performance of parser

Refactor to remove global string replacement ( except the one for pgn writer comment %)

Side effect of this change:

Performance is a bit improved

```
55 games in 27 ms
55 games in 26 ms
55 games in 21 ms
55 games in 42 ms
55 games in 20 ms
55 games in 18 ms
55 games in 18 ms
55 games in 18 ms
55 games in 17 ms
55 games in 19 ms
Average = 410 microseconds per game
          2439 games per second
```


Error messages can show the location of the error in the whole string (not in splited string as before)

Example:
```
Cannot parse pgn: [4.4]: Invalid chess move

2. bla
   ^
[abc "def"]

1. e4 { hello world } Nc6
2. bla
```