### PR TITLE
Antichess insufficient material

### DIFF
--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -53,8 +53,7 @@ case object Antichess
   // blockade or stalemate. Only one player can win if the only remaining pieces are two knights
   override def opponentHasInsufficientMaterial(situation: Situation) = {
     // Exit early if we are not in a situation with only knights
-    val knights = situation.board.pieces.values.forall(p => p.is(Knight)) && situation.board.pieces.values
-      .exists(_.is(Knight))
+    val knights = situation.board.pieces.values.forall(p => p.is(Knight)) 
 
     lazy val drawnKnights = situation.board.actors.values.partition(_.is(White)) match {
       case (whitePieces, blackPieces) =>

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -53,10 +53,11 @@ case object Antichess
   // blockade or stalemate. Only one player can win if the only remaining pieces are two knights
   override def opponentHasInsufficientMaterial(situation: Situation) = {
     // Exit early if we are not in a situation with only knights
-    val knights = situation.board.pieces.values.forall(p => p.is(Knight)) && situation.board.pieces.values.exists(_.is(Knight))
+    val knights = situation.board.pieces.values.forall(p => p.is(Knight)) && situation.board.pieces.values
+      .exists(_.is(Knight))
 
-    lazy val drawnKnights = situation.actors.values.partition(_.is(White)) match {
-      case (whitePieces, blackPieces) => 
+    lazy val drawnKnights = situation.board.actors.values.partition(_.is(White)) match {
+      case (whitePieces, blackPieces) =>
         val whiteKnights = whitePieces.filter(_.is(Knight))
         val blackKnights = blackPieces.filter(_.is(Knight))
 
@@ -64,13 +65,13 @@ case object Antichess
         if (
           whiteKnights.to(Set).size != 1 ||
           blackKnights.to(Set).size != 1
-        ) false 
+        ) false
         else {
           for {
-            whiteKnightLight <- whiteKnight.headOption map (_.pos.isLight)
-            blackKnightLight <- blackKnight.headOption map (_.pos.isLight)
+            whiteKnightLight <- whiteKnights.headOption map (_.pos.isLight)
+            blackKnightLight <- blackKnights.headOption map (_.pos.isLight)
           } yield {
-            whiteKnightLight == blackKnightLight 
+            whiteKnightLight == blackKnightLight
           }
         } getOrElse false
     }

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -51,32 +51,22 @@ case object Antichess
 
   // In antichess, there is no checkmate condition therefore a player may only draw either by agreement,
   // blockade or stalemate. Only one player can win if the only remaining pieces are two knights
-  override def opponentHasInsufficientMaterial(situation: Situation) = {
+  override def opponentHasInsufficientMaterial(situation: Situation) =
     // Exit early if we are not in a situation with only knights
-    val knights = situation.board.pieces.values.forall(p => p.is(Knight))
+    situation.board.pieces.values.forall(_.is(Knight)) && {
 
-    lazy val drawnKnights = situation.board.actors.values.partition(_.is(White)) match {
-      case (whitePieces, blackPieces) =>
-        val whiteKnights = whitePieces.filter(_.is(Knight))
-        val blackKnights = blackPieces.filter(_.is(Knight))
+      val whiteKnights = situation.board.actorsOf(White)
+      val blackKnights = situation.board.actorsOf(Black)
 
-        // We consider the case where a player has two knights
-        if (
-          whiteKnights.to(Set).size != 1 ||
-          blackKnights.to(Set).size != 1
-        ) false
-        else {
-          for {
-            whiteKnightLight <- whiteKnights.headOption map (_.pos.isLight)
-            blackKnightLight <- blackKnights.headOption map (_.pos.isLight)
-          } yield {
-            whiteKnightLight == blackKnightLight
-          }
-        } getOrElse false
+      // We consider the case where a player has two knights
+      if (whiteKnights.size != 1 || blackKnights.size != 1) false
+      else {
+        for {
+          whiteKnight <- whiteKnights.headOption
+          blackKnight <- blackKnights.headOption
+        } yield whiteKnight.pos.isLight == blackKnight.pos.isLight
+      } getOrElse false
     }
-
-    knights && drawnKnights
-  }
 
   // No player can win if the only remaining pieces are opposing bishops on different coloured
   // diagonals. There may be pawns that are incapable of moving and do not attack the right color

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -53,7 +53,7 @@ case object Antichess
   // blockade or stalemate. Only one player can win if the only remaining pieces are two knights
   override def opponentHasInsufficientMaterial(situation: Situation) = {
     // Exit early if we are not in a situation with only knights
-    val knights = situation.board.pieces.values.forall(p => p.is(Knight)) 
+    val knights = situation.board.pieces.values.forall(p => p.is(Knight))
 
     lazy val drawnKnights = situation.board.actors.values.partition(_.is(White)) match {
       case (whitePieces, blackPieces) =>

--- a/src/test/scala/AntichessVariantTest.scala
+++ b/src/test/scala/AntichessVariantTest.scala
@@ -259,7 +259,7 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       }
     }
 
-    "Opponent has insufficient material when there are only two remaining knights" in {
+    "Opponent has insufficient material when there are only two remaining knights on same color squares" in {
       val position     = FEN("8/8/3n2N1/8/8/8/8/8 w - -")
       val originalGame = fenToGame(position, Antichess)
 
@@ -267,6 +267,17 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
 
       newGame must beValid.like { case opponentHasInsufficientMaterialGame =>
         opponentHasInsufficientMaterialGame.situation.opponentHasInsufficientMaterial must beTrue
+      }
+    }
+
+    "Opponent does not have insufficient material when there are only two remaining knights on opposite color squares" in {
+      val position     = FEN("7n/8/8/8/8/8/8/N7 w - -")
+      val originalGame = fenToGame(position, Antichess)
+
+      val newGame = originalGame flatMap (_.playMoves(Pos.A1 -> Pos.B3))
+
+      newGame must beValid.like { case opponentHasInsufficientMaterialGame =>
+        opponentHasInsufficientMaterialGame.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
 

--- a/src/test/scala/AntichessVariantTest.scala
+++ b/src/test/scala/AntichessVariantTest.scala
@@ -259,6 +259,17 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
       }
     }
 
+    "Opponent has insufficient material when there are only two remaining knights" in {
+      val position     = FEN("8/8/3n2N1/8/8/8/8/8 w - -")
+      val originalGame = fenToGame(position, Antichess)
+
+      val newGame = originalGame flatMap (_.playMoves(Pos.G6 -> Pos.F4))
+
+      newGame must beValid.like { case opponentHasInsufficientMaterialGame =>
+        opponentHasInsufficientMaterialGame.situation.opponentHasInsufficientMaterial must beTrue
+      }
+    }
+
     "Not be drawn on insufficient mating material" in {
       val position  = FEN("4K3/8/1b6/8/8/8/5B2/3k4 b - -")
       val maybeGame = fenToGame(position, Antichess)

--- a/src/test/scala/AntichessVariantTest.scala
+++ b/src/test/scala/AntichessVariantTest.scala
@@ -265,19 +265,19 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
 
       val newGame = originalGame flatMap (_.playMoves(Pos.G6 -> Pos.F4))
 
-      newGame must beValid.like { case opponentHasInsufficientMaterialGame =>
-        opponentHasInsufficientMaterialGame.situation.opponentHasInsufficientMaterial must beTrue
+      newGame must beValid.like {
+        _.situation.opponentHasInsufficientMaterial must beTrue
       }
     }
 
-    "Opponent does not have insufficient material when there are only two remaining knights on opposite color squares" in {
+    "Opponent has sufficient material when there are only two remaining knights on opposite color squares" in {
       val position     = FEN("7n/8/8/8/8/8/8/N7 w - -")
       val originalGame = fenToGame(position, Antichess)
 
       val newGame = originalGame flatMap (_.playMoves(Pos.A1 -> Pos.B3))
 
-      newGame must beValid.like { case opponentHasInsufficientMaterialGame =>
-        opponentHasInsufficientMaterialGame.situation.opponentHasInsufficientMaterial must beFalse
+      newGame must beValid.like {
+        _.situation.opponentHasInsufficientMaterial must beFalse
       }
     }
 


### PR DESCRIPTION
The change solves issue #296 by implementing the `opponentHasInsufficientMaterial` method. The implementation resembles the implementation of the `isInsufficientMaterial` method.