### PR TITLE
Update pgn for three check winning move

### DIFF
--- a/src/main/scala/format/pgn/Dumper.scala
+++ b/src/main/scala/format/pgn/Dumper.scala
@@ -6,7 +6,7 @@ object Dumper {
   def apply(situation: Situation, data: chess.Move, next: Situation): String = {
     import data._
 
-    ((promotion, piece.role) match {
+    val base = (promotion, piece.role) match {
       case _ if castles =>
         if (orig ?> dest) "O-O-O" else "O-O"
 
@@ -40,22 +40,19 @@ object Dumper {
         } else {
           orig.key
         }
-
         s"${role.pgn}$disambiguation${if (captures) "x" else ""}${dest.key}"
-    }) + {
-      if (next.winner.isDefined) "#"
-      else if (next.check) "+"
-      else ""
     }
+
+    s"$base${checkOrWinnerSymbol(next)}"
   }
 
-  def apply(data: chess.Drop, next: Situation): String = {
-    data.toUci.uci + {
-      if (next.winner.isDefined) "#"
-      else if (next.check) "+"
-      else ""
-    }
-  }
+  def apply(data: chess.Drop, next: Situation): String =
+    s"${data.toUci.uci}${checkOrWinnerSymbol(next)}"
+
+  private def checkOrWinnerSymbol(next: Situation): String =
+    if (next.winner.isDefined) "#"
+    else if (next.check) "+"
+    else ""
 
   def apply(data: chess.Move): String =
     apply(

--- a/src/main/scala/format/pgn/Dumper.scala
+++ b/src/main/scala/format/pgn/Dumper.scala
@@ -43,18 +43,16 @@ object Dumper {
 
         s"${role.pgn}$disambiguation${if (captures) "x" else ""}${dest.key}"
     }) + {
-      if (next.check) {
-        if (next.checkMate) "#" else "+"
-      } else if (next.winner.isDefined) "#"
+      if (next.winner.isDefined) "#"
+      else if (next.check) "+"
       else ""
     }
   }
 
   def apply(data: chess.Drop, next: Situation): String = {
     data.toUci.uci + {
-      if (next.check) {
-        if (next.checkMate) "#" else "+"
-      } else if (next.winner.isDefined) "#"
+      if (next.winner.isDefined) "#"
+      else if (next.check) "+"
       else ""
     }
   }

--- a/src/test/scala/format/pgn/DumperTest.scala
+++ b/src/test/scala/format/pgn/DumperTest.scala
@@ -5,6 +5,7 @@ import format.Forsyth
 import Pos._
 
 import chess.format.FEN
+import chess.variant.ThreeCheck
 
 class DumperTest extends ChessTest {
 
@@ -66,6 +67,18 @@ class DumperTest extends ChessTest {
     E2 -> A6
   )
 
+  val threeCheck = Game(Board init ThreeCheck).playMoves(
+    E2 -> E4,
+    C7 -> C5,
+    F1 -> C4,
+    B8 -> C6,
+    C4 -> F7,
+    E8 -> F7,
+    D1 -> H5,
+    G7 -> G6,
+    H5 -> G6
+  )
+
   "standard game" should {
     "move list" in {
       "Gioachine Greco" in {
@@ -79,6 +92,16 @@ class DumperTest extends ChessTest {
             .split(' ')
             .toList
         }
+      }
+    }
+  }
+
+  "three check variant" should {
+    "move list" in {
+      threeCheck map (_.pgnMoves) must beValid.like { case ms =>
+        ms must_== "e4 c5 Bc4 Nc6 Bxf7+ Kxf7 Qh5+ g6 Qxg6#"
+          .split(' ')
+          .toList
       }
     }
   }


### PR DESCRIPTION
See https://github.com/lichess-org/lila/issues/11659 for background.

Note that this will update behaviour for standard games and all variants, such that all games that end with a winner defined will have the final move appended with `#`. I'm not sure if this is desired behaviour, or if we only want to fix the "three checks" variant. If we want to limit the blast radius a bit, another approach could be to update the conditional logic to only append `#` in the case where `next.winner.isDefined` and `next.check` are both true (solving the "three checks" problem with less potential for unforeseen/undesirable `#` annotations in other games).