### PR TITLE
 Remove default value for UnmovedRooks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val scalachess = Project("scalachess", file(".")).settings(
 )
 
 ThisBuild / organization           := "org.lichess"
-ThisBuild / version                := "14.0.0-RC5"
+ThisBuild / version                := "14.0.0-RC6"
 ThisBuild / scalaVersion           := "3.2.1"
 ThisBuild / licenses += "AGPL-3.0" -> url("https://opensource.org/licenses/AGPL-3.0")
 

--- a/src/main/scala/Castles.scala
+++ b/src/main/scala/Castles.scala
@@ -107,6 +107,7 @@ object UnmovedRooks extends OpaqueBitboard[UnmovedRooks]:
   // for lila testing only
   val default: UnmovedRooks = UnmovedRooks(Bitboard.rank(Rank.First) | Bitboard.rank(Rank.Eighth))
   val corners: UnmovedRooks = CORNERS
+  val none: UnmovedRooks    = empty
 
   def apply(b: Bitboard): UnmovedRooks   = b.value
   def apply(set: Set[Pos]): UnmovedRooks = set.foldLeft(empty)((b, p) => b | p.bitboard)

--- a/src/main/scala/History.scala
+++ b/src/main/scala/History.scala
@@ -3,7 +3,6 @@ package chess
 import format.Uci
 import cats.kernel.Monoid
 import bitboard.Bitboard
-// import Castles.*
 
 // Checks received by the respective side.
 case class CheckCount(white: Int = 0, black: Int = 0):
@@ -25,7 +24,7 @@ case class History(
     positionHashes: PositionHash = Monoid[PositionHash].empty,
     castles: Castles = Castles.all,
     checkCount: CheckCount = CheckCount(0, 0),
-    unmovedRooks: UnmovedRooks = UnmovedRooks.corners,
+    unmovedRooks: UnmovedRooks,
     halfMoveClock: HalfMoveClock = HalfMoveClock(0),
     // fullMoves: FullMoveNumber = FullMoveNumber(0), // do we need it nows? => no
     // possible en-passant square
@@ -81,10 +80,11 @@ object History:
     History(
       lastMove = lastMove flatMap Uci.apply,
       castles = Castles(castles),
+      unmovedRooks = UnmovedRooks.corners,
       positionHashes = Monoid[PositionHash].empty
     )
 
   def castle(color: Color, kingSide: Boolean, queenSide: Boolean) =
-    History(castles = Castles.all.update(color, kingSide, queenSide))
+    History(castles = Castles.all.update(color, kingSide, queenSide), unmovedRooks = UnmovedRooks.corners)
 
-  def noCastle = History(castles = Castles.none)
+  def noCastle = History(castles = Castles.none, unmovedRooks = UnmovedRooks.none)

--- a/src/main/scala/bitboard/Board.scala
+++ b/src/main/scala/bitboard/Board.scala
@@ -234,7 +234,8 @@ case class Board(
 
   def piece(p: Piece): Bitboard = color(p.color) & role(p.role)
 
-  // use to guess unmovedRooks from board
+  // guess unmovedRooks from board
+  // we assume rooks are on their initial position
   def defaultUnmovedRooks: UnmovedRooks =
     val wr = rooks & white & Bitboard.rank(White.backRank)
     val br = rooks & black & Bitboard.rank(Black.backRank)

--- a/src/test/scala/ChessTest.scala
+++ b/src/test/scala/ChessTest.scala
@@ -9,6 +9,8 @@ import org.specs2.mutable.Specification
 import chess.format.{ EpdFen, Fen, Visual }
 import chess.variant.Variant
 import bitboard.Board as BBoard
+import cats.kernel.Monoid
+import chess.format.Uci
 
 trait ChessTest extends Specification with ValidatedMatchers:
 
@@ -82,7 +84,7 @@ trait ChessTest extends Specification with ValidatedMatchers:
     }
 
   def makeBoard(pieces: (Pos, Piece)*): Board =
-    Board(BBoard.fromMap(pieces.toMap), History(), chess.variant.Standard)
+    Board(BBoard.fromMap(pieces.toMap), defaultHistory(), chess.variant.Standard)
 
   def makeBoard(str: String, variant: Variant) =
     Visual << str withVariant variant
@@ -124,3 +126,27 @@ trait ChessTest extends Specification with ValidatedMatchers:
     (makeEmptyBoard place (piece, pos)) flatMap { b =>
       b actorAt pos map (_.destinations)
     }
+
+  def defaultHistory(
+      lastMove: Option[Uci] = None,
+      // turn: Color,
+      positionHashes: PositionHash = Monoid[PositionHash].empty,
+      castles: Castles = Castles.all,
+      checkCount: CheckCount = CheckCount(0, 0),
+      unmovedRooks: UnmovedRooks = UnmovedRooks.corners,
+      halfMoveClock: HalfMoveClock = HalfMoveClock(0),
+      // fullMoves: FullMoveNumber = FullMoveNumber(0), // do we need it nows? => no
+      // possible en-passant square
+      epSquare: Option[Pos] = None
+  ) = History(
+    lastMove = lastMove,
+    // turn = turn,
+    positionHashes = positionHashes,
+    castles = castles,
+    checkCount = checkCount,
+    unmovedRooks = unmovedRooks,
+    halfMoveClock = halfMoveClock,
+    // fullMoves = fullMoves,
+    // possible en-passant square
+    epSquare = epSquare
+  )

--- a/src/test/scala/HistoryTest.scala
+++ b/src/test/scala/HistoryTest.scala
@@ -7,11 +7,11 @@ class HistoryTest extends ChessTest:
   "threefold repetition" should {
     def toHash(a: Int) = PositionHash(Array(a.toByte, 0.toByte, 0.toByte))
     def makeHistory(positions: List[Int]) =
-      (positions map toHash).foldLeft(History()) { (history, hash) =>
+      (positions map toHash).foldLeft(defaultHistory()) { (history, hash) =>
         history.copy(positionHashes = Monoid[PositionHash].combine(hash, history.positionHashes))
       }
     "empty history" in {
-      History().threefoldRepetition must_== false
+      defaultHistory().threefoldRepetition must_== false
     }
     "not 3 same elements" in {
       val history = makeHistory(List(1, 2, 3, 4, 5, 2, 5, 6, 23, 55))
@@ -29,9 +29,9 @@ class HistoryTest extends ChessTest:
 
   "set half move clock" should {
     "set 0" in {
-      History().setHalfMoveClock(HalfMoveClock(0)).halfMoveClock must_== HalfMoveClock(0)
+      defaultHistory().setHalfMoveClock(HalfMoveClock(0)).halfMoveClock must_== HalfMoveClock(0)
     }
     "set 5" in {
-      History().setHalfMoveClock(HalfMoveClock(5)).halfMoveClock must_== HalfMoveClock(5)
+      defaultHistory().setHalfMoveClock(HalfMoveClock(5)).halfMoveClock must_== HalfMoveClock(5)
     }
   }

--- a/src/test/scala/PawnTest.scala
+++ b/src/test/scala/PawnTest.scala
@@ -81,17 +81,17 @@ class PawnTest extends ChessTest:
           board destsFrom D5 must bePoss(D6)
         }
         "with irrelevant history" in {
-          board withHistory History(
+          board withHistory defaultHistory(
             lastMove = Option(Uci.Move(A2, A4))
           ) destsFrom D5 must bePoss(D6)
         }
         "with relevant history on the left" in {
-          board withHistory History(
+          board withHistory defaultHistory(
             epSquare = Option(C6)
           ) destsFrom D5 must bePoss(D6, C6)
         }
         "with relevant history on the right" in {
-          board withHistory History(
+          board withHistory defaultHistory(
             epSquare = Option(E6)
           ) destsFrom D5 must bePoss(D6, E6)
         }
@@ -100,7 +100,7 @@ class PawnTest extends ChessTest:
         makeBoard(
           D5 -> White.pawn,
           E5 -> Black.rook
-        ) withHistory History(
+        ) withHistory defaultHistory(
           lastMove = Option(Uci.Move(E7, E5))
         ) destsFrom D5 must bePoss(D6)
       }
@@ -108,7 +108,7 @@ class PawnTest extends ChessTest:
         makeBoard(
           D5 -> White.pawn,
           E5 -> White.pawn
-        ) withHistory History(
+        ) withHistory defaultHistory(
           lastMove = Option(Uci.Move(E7, E5))
         ) destsFrom D5 must bePoss(D6)
       }
@@ -191,7 +191,7 @@ class PawnTest extends ChessTest:
           board destsFrom D4 must bePoss(D3)
         }
         "with relevant history on the left" in {
-          board withHistory History(
+          board withHistory defaultHistory(
             epSquare = Option(C3)
           ) destsFrom D4 must bePoss(D3, C3)
         }
@@ -200,7 +200,7 @@ class PawnTest extends ChessTest:
         makeBoard(
           D4 -> Black.pawn,
           E4 -> White.rook
-        ) withHistory History(
+        ) withHistory defaultHistory(
           lastMove = Option(Uci.Move(E2, E4))
         ) destsFrom D4 must bePoss(D3)
       }

--- a/src/test/scala/format/Visual.scala
+++ b/src/test/scala/format/Visual.scala
@@ -30,7 +30,7 @@ object Visual:
       }) flatten,
       variant = chess.variant.Variant.default
     )
-    b.withHistory(History().copy(unmovedRooks = b.board.defaultUnmovedRooks))
+    b.withHistory(History(unmovedRooks = b.board.defaultUnmovedRooks))
 
   def >>(board: Board): String = >>|(board, Map.empty)
 


### PR DESCRIPTION
This is to enforce clients (lila) initiate `UnmovedRooks`. scalachess now depends on the correctness of `UnmovedRooks` to generate castling moves.