### PR TITLE
Make castling uci always 960 notation

### DIFF
--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -387,10 +387,12 @@ case class Situation(board: Board, color: Color):
   // Here is the rules:
   // if the variant is Standard => 2 moves
   // if the variant is Chess960 => 1 move
-  // if the variatn is not either of those two then
+  // if the variant is not either of those two then
   //     if King and Rook are in standard position  => 2 moves
   //     else => 1 move
   // check logic in isChess960 function
+  // make sure that the 960 move is first since it will be the representative
+  // move and we want 960 uci notation
   private def castle(king: Pos, kingTo: Pos, rook: Pos, rookTo: Pos): List[Move] =
     val after = for
       b1    <- board.take(king)
@@ -404,7 +406,7 @@ case class Situation(board: Board, color: Color):
       else if board.variant.chess960 then true
       else king.file != File.E || !(rook.file == File.A || rook.file == File.H)
 
-    val destInput = if (!isChess960) then List(kingTo, rook) else List(rook)
+    val destInput = if (!isChess960) then List(rook, kingTo) else List(rook)
 
     for
       a            <- after.toList

--- a/src/test/scala/ReplayTest.scala
+++ b/src/test/scala/ReplayTest.scala
@@ -58,3 +58,19 @@ class ReplayTest extends ChessTest:
     error must beNone
     steps.size === sans.size
   }
+
+  "castling always 960 notation" in {
+    val sans: Vector[SanStr] =
+      SanStr from "d4 Nf6 c4 g6 Nc3 Bg7 e4 d6 f3 O-O Be3 e5 d5 Nh5 Qd2 Qh4+ g3 Qe7 O-O-O"
+        .split(' ')
+        .toVector
+    val (game, steps, error) = chess.Replay.gameMoveWhileValid(
+      sans,
+      Fen.Epd.initial,
+      variant.Standard
+    )
+    error must beNone
+    steps.size must_== sans.size
+    steps(9)._2.uci.uci must_== "e8h8"
+    steps(18)._2.uci.uci must_== "e1a1"
+  }


### PR DESCRIPTION
Fixes lichess-org/lila#12206

We want castling to always use 960 notation so that we can just compare uci to check whether it's the same move. Since the representative move is just the first one found (https://github.com/lichess-org/scalachess/blame/master/src/main/scala/format/pgn/parsingModel.scala#L132), make sure that the first one is the 960 move (i.e. where the king moves onto the rook).

Doesn't really feel like a super solid solution but I guess it's also how it worked before:
- https://github.com/lichess-org/scalachess/blob/a44879b2ae9deaa94b887a2df0b5912c55752304/src/main/scala/Actor.scala#L136
- https://github.com/lichess-org/scalachess/blob/a44879b2ae9deaa94b887a2df0b5912c55752304/src/main/scala/format/pgn/parsingModel.scala#L135