### PR TITLE
Add sharedAny and sharedNone for Bitboard

### DIFF
--- a/src/main/scala/Castles.scala
+++ b/src/main/scala/Castles.scala
@@ -11,7 +11,7 @@ object Castles extends OpaqueBitboard[Castles]:
 
   extension (c: Castles)
 
-    inline def can(inline color: Color): Boolean           = (c & Bitboard.rank(color.backRank)).nonEmpty
+    inline def can(inline color: Color): Boolean           = c.sharedAny(Bitboard.rank(color.backRank))
     inline def can(inline color: Color, inline side: Side) = c.contains(color.at(side))
 
     def whiteKingSide: Boolean  = c.contains(H1)

--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -260,7 +260,6 @@ case class Situation(board: Board, color: Color):
 
   // TODO verify kings & rooks are in back rank only
   private def genCastling: List[Move] =
-    import Castles.*
     ourKings.headOption.fold(Nil) { king =>
       // can castle but which side?
       if !board.history.castles.can(color) || king.rank != color.backRank then Nil
@@ -277,7 +276,7 @@ case class Situation(board: Board, color: Color):
             if board.variant.chess960 || board.variant.fromPosition
             then (Bitboard.between(king, rook) | Bitboard.between(king, kingTo))
             else Bitboard.between(king, rook)
-          if (path & (board.occupied & ~rook.bb)).isEmpty
+          if path.sharedNone(board.occupied, ~rook.bb)
           kingPath = Bitboard.between(king, kingTo) | king.bb
           if kingPath.occupiedSquares.forall(board.variant.castleCheckSafeSquare(this, king, _))
           moves <- castle(king, kingTo, rook, rookTo)

--- a/src/main/scala/UnmovedRooks.scala
+++ b/src/main/scala/UnmovedRooks.scala
@@ -25,10 +25,10 @@ object UnmovedRooks extends OpaqueBitboard[UnmovedRooks]:
     // same rank return Some(None) (because we cannot guess)
     // If there are two rooks on the same rank, return the side of the rook
     def side(pos: Pos): Option[Option[Side]] =
-      val bitboard = pos.bb
-      if (ur & bitboard).isEmpty then None
+      val rook = pos.bb
+      if ur.sharedAny(rook) then None
       else
-        (ur & ~bitboard & Bitboard.rank(pos.rank)).first match
+        (ur & ~rook & Bitboard.rank(pos.rank)).first match
           case Some(otherRook) =>
             if (otherRook.file > pos.file) then Some(Some(QueenSide))
             else Some(Some(KingSide))

--- a/src/main/scala/UnmovedRooks.scala
+++ b/src/main/scala/UnmovedRooks.scala
@@ -26,7 +26,7 @@ object UnmovedRooks extends OpaqueBitboard[UnmovedRooks]:
     // If there are two rooks on the same rank, return the side of the rook
     def side(pos: Pos): Option[Option[Side]] =
       val rook = pos.bb
-      if ur.sharedAny(rook) then None
+      if ur.sharedNone(rook) then None
       else
         (ur & ~rook & Bitboard.rank(pos.rank)).first match
           case Some(otherRook) =>

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -53,11 +53,18 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
     def removeFirst: A = (a.value & (a.value - 1L)).bb
 
     // check if the intersection of all bitboards is not empty
-    def sharedAny(o: A, xs: A*): Boolean =
-      (a.value & xs.foldLeft(o.value)(_ & _.value)) != 0L
+    def sharedAny(o: Long, xs: Long*): Boolean =
+      (a & xs.foldLeft(o)(_ & _)).nonEmpty
+
+    // check if the intersection of all bitboards is not empty
+    def sharedAny[B](o: B, xs: B*)(using sr: BitboardRuntime[B]): Boolean =
+      (a & xs.foldLeft(sr(o))(_ & sr(_))).nonEmpty
 
     // check if the intersection of all bitboards is empty
-    def sharedNone(o: A, xs: A*): Boolean = !sharedAny(o, xs*)
+    def sharedNone(o: Long, xs: Long*): Boolean = !sharedAny(o, xs*)
+
+    // check if the intersection of all bitboards is empty
+    def sharedNone[B](o: B, xs: B*)(using BitboardRuntime[B]): Boolean = !sharedAny(o, xs*)
 
     def fold[B](init: B)(f: (B, Pos) => B): B =
       var b      = a.value

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -52,8 +52,12 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
     // remove the first non empty position
     def removeFirst: A = (a.value & (a.value - 1L)).bb
 
+    // check if the intersection of all bitboards is not empty
     def sharedAny(o: A, xs: A*): Boolean =
       (a.value & xs.foldLeft(o.value)(_ & _.value)) != 0L
+
+    // check if the intersection of all bitboards is empty
+    def sharedNone(o: A, xs: A*): Boolean = !sharedAny(o, xs*)
 
     def fold[B](init: B)(f: (B, Pos) => B): B =
       var b      = a.value

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -52,7 +52,8 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
     // remove the first non empty position
     def removeFirst: A = (a.value & (a.value - 1L)).bb
 
-    def hasAny(o: A): Boolean = (a.value & o.value) != 0L
+    def sharedAny(o: A, xs: A*): Boolean =
+      (a.value & xs.foldLeft(o.value)(_ & _.value)) != 0L
 
     def fold[B](init: B)(f: (B, Pos) => B): B =
       var b      = a.value

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -52,6 +52,8 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
     // remove the first non empty position
     def removeFirst: A = (a.value & (a.value - 1L)).bb
 
+    def hasAny(o: A): Boolean = (a.value & o.value) != 0L
+
     def fold[B](init: B)(f: (B, Pos) => B): B =
       var b      = a.value
       var result = init

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -35,9 +35,9 @@ case object Atomic
     */
   override def kingThreatened(board: Board, color: Color): Check = Check {
     import board.board.{ byColor, kings }
-    val their = byColor(!color)
+    val theirKings = byColor(!color) & kings
     kings(color).exists { k =>
-      (their & k.kingAttacks & kings).isEmpty && attackersWithoutKing(
+      k.kingAttacks.sharedNone(theirKings) && attackersWithoutKing(
         board,
         board.board.occupied,
         k,
@@ -67,8 +67,8 @@ case object Atomic
   override def castleCheckSafeSquare(situation: Situation, kingFrom: Pos, kingTo: Pos): Boolean =
     // In Atomic, when the kings are connected, checks do not apply
     import situation.board.board.{ byColor, kings }
-    val their = byColor(!situation.color)
-    (kingTo.kingAttacks & their & kings).nonEmpty || attackersWithoutKing(
+    val theirKings = byColor(!situation.color) & kings
+    kingTo.kingAttacks.sharedAny(theirKings) || attackersWithoutKing(
       situation.board,
       (situation.board.occupied ^ kingFrom.bb),
       kingTo,

--- a/src/main/scala/variant/KingOfTheHill.scala
+++ b/src/main/scala/variant/KingOfTheHill.scala
@@ -18,7 +18,7 @@ case object KingOfTheHill
   private val center = 0x1818000000L
 
   override def specialEnd(situation: Situation) =
-    (situation.board.kingPosOf(!situation.color) & center).nonEmpty
+    situation.board.kingPosOf(!situation.color).sharedAny(center)
 
   /** You only need a king to be able to win in this variant
     */

--- a/src/main/scala/variant/RacingKings.scala
+++ b/src/main/scala/variant/RacingKings.scala
@@ -47,7 +47,7 @@ case object RacingKings
   override def opponentHasInsufficientMaterial(situation: Situation) = false
 
   private def reachedGoal(board: Board, color: Color) =
-    (board.kingPosOf(color) & Bitboard.rank(Rank.Eighth)).nonEmpty
+    board.kingPosOf(color).sharedAny(Bitboard.rank(Rank.Eighth))
 
   private def reachesGoal(move: Move) =
     reachedGoal(move.situationAfter.board, move.piece.color)

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -146,10 +146,10 @@ abstract class Variant private[variant] (
   @nowarn def finalizeBoard(board: Board, uci: format.Uci, captured: Option[Piece]): Board = board
 
   protected def pawnsOnPromotionRank(board: Board, color: Color) =
-    (board(color, Pawn) & Bitboard.rank(color.promotablePawnRank)).nonEmpty
+    board(color, Pawn).sharedAny(Bitboard.rank(color.promotablePawnRank))
 
   protected def pawnsOnBackRank(board: Board, color: Color) =
-    (board(color, Pawn) & Bitboard.rank(color.backRank)).nonEmpty
+    board(color, Pawn).sharedAny(Bitboard.rank(color.backRank))
 
   protected def validSide(board: Board, strict: Boolean)(color: Color) =
     board(color, King).count == 1 &&

--- a/src/test/scala/bitboard/Fen.scala
+++ b/src/test/scala/bitboard/Fen.scala
@@ -26,8 +26,8 @@ case class Fen(board: Board, state: State):
         result
       case Move.EnPassant(from, to) =>
         val newOccupied = (occupied ^ from.bb ^ to.withRankOf(from).bb) | to.bb
-        (king.rookAttacks(newOccupied) & them & (board.rooks ^ board.queens)).isEmpty &&
-        (king.bishopAttacks(newOccupied) & them & (board.bishops ^ board.queens)).isEmpty
+        king.rookAttacks(newOccupied).sharedNone(them, (board.rooks ^ board.queens)) &&
+        king.bishopAttacks(newOccupied).sharedNone(them, (board.bishops ^ board.queens))
       case _ => true
 
   // TODO now it works with valid move only

--- a/src/test/scala/bitboard/OpaqueBitboardTest.scala
+++ b/src/test/scala/bitboard/OpaqueBitboardTest.scala
@@ -80,17 +80,27 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
     }
   }
 
-  test("hasAny should be true when the two bitboards have at least one common square") {
+  test("sharedAny should be true when the two bitboards have at least one common square") {
     forAll { (b1: Bitboard, b2: Bitboard, p: Pos) =>
-      b1.addPos(p).hasAny(b2.addPos(p))
+      b1.addPos(p).sharedAny(b2.addPos(p))
     }
   }
 
-  test("hasAny and intersection should be consistent") {
+  test("sharedAny and intersection should be consistent") {
     forAll { (s1: Set[Pos], s2: Set[Pos]) =>
       val b1 = Bitboard(s1)
       val b2 = Bitboard(s2)
       val s  = s1 intersect s2
-      b1.hasAny(b2) == s.nonEmpty
+      b1.sharedAny(b2) == s.nonEmpty
+    }
+  }
+
+  test("sharedAny and intersection should be consistent") {
+    forAll { (s1: Set[Pos], s2: Set[Pos], xs: List[Set[Pos]]) =>
+      val b1 = Bitboard(s1)
+      val b2 = Bitboard(s2)
+      val s  = s1.intersect(xs.foldLeft(s2)(_ intersect _))
+      val bs = xs.map(Bitboard(_))
+      b1.sharedAny(b2, bs*) == s.nonEmpty
     }
   }

--- a/src/test/scala/bitboard/OpaqueBitboardTest.scala
+++ b/src/test/scala/bitboard/OpaqueBitboardTest.scala
@@ -79,3 +79,18 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
       assertEquals(bb.first, bb.occupiedSquares.minByOption(_.value))
     }
   }
+
+  test("hasAny should be true when the two bitboards have at least one common square") {
+    forAll { (b1: Bitboard, b2: Bitboard, p: Pos) =>
+      b1.addPos(p).hasAny(b2.addPos(p))
+    }
+  }
+
+  test("hasAny and intersection should be consistent") {
+    forAll { (s1: Set[Pos], s2: Set[Pos]) =>
+      val b1 = Bitboard(s1)
+      val b2 = Bitboard(s2)
+      val s  = s1 intersect s2
+      b1.hasAny(b2) == s.nonEmpty
+    }
+  }


### PR DESCRIPTION
We use `(a & b).nonEmpty` or `(a & b).isEmpty` in several places.
So they're deserve an abstraction in `OpaqueBitboard`.
I named them `sharedAny` and `sharedNone` respectively, but not sure they're the best.
Welcome any naming suggestion.