### PR TITLE
MoveOrDrop as union type & bump version 14.5.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val scalachess = Project("scalachess", file(".")).settings(
 )
 
 ThisBuild / organization           := "org.lichess"
-ThisBuild / version                := "14.4.0"
+ThisBuild / version                := "14.5.0"
 ThisBuild / scalaVersion           := "3.2.2"
 ThisBuild / licenses += "AGPL-3.0" -> url("https://opensource.org/licenses/AGPL-3.0")
 

--- a/src/main/scala/Game.scala
+++ b/src/main/scala/Game.scala
@@ -87,9 +87,7 @@ case class Game(
   def apply(uci: Uci.Move): Validated[ErrorStr, (Game, Move)] = apply(uci.orig, uci.dest, uci.promotion)
   def apply(uci: Uci.Drop): Validated[ErrorStr, (Game, Drop)] = drop(uci.role, uci.pos)
   def apply(uci: Uci): Validated[ErrorStr, (Game, MoveOrDrop)] =
-    uci match
-      case u: Uci.Move => apply(u) map { case (g, m) => g -> Left(m) }
-      case u: Uci.Drop => apply(u) map { case (g, d) => g -> Right(d) }
+    apply(uci) map { case (g, m) => g -> m }
 
   inline def isStandardInit = board.pieces == chess.variant.Standard.pieces
 

--- a/src/main/scala/MoveOrDrop.scala
+++ b/src/main/scala/MoveOrDrop.scala
@@ -9,7 +9,7 @@ object MoveOrDrop:
     def isMove = md.isInstanceOf[Move]
     def isDrop = md.isInstanceOf[Drop]
 
-    def fold[A](move: Move => A, drop: Drop => A): A =
+    inline def fold[A](move: Move => A, drop: Drop => A): A =
       md match
         case m: Move => move(m)
         case d: Drop => drop(d)
@@ -17,12 +17,12 @@ object MoveOrDrop:
     def move: Option[Move] = md.fold(Some(_), _ => None)
     def drop: Option[Drop] = md.fold(_ => None, Some(_))
 
-    def applyVariantEffect: MoveOrDrop =
+    inline def applyVariantEffect: MoveOrDrop =
       md match
         case m: Move => m.applyVariantEffect
         case d: Drop => d
 
-    def toUci: Uci =
+    inline def toUci: Uci =
       md match
         case m: Move => m.toUci
         case d: Drop => d.toUci

--- a/src/main/scala/MoveOrDrop.scala
+++ b/src/main/scala/MoveOrDrop.scala
@@ -1,0 +1,24 @@
+package chess
+
+import chess.format.Uci
+
+type MoveOrDrop = Move | Drop
+
+extension (md: MoveOrDrop)
+  def isMove = md.isInstanceOf[Move]
+  def isDrop = md.isInstanceOf[Drop]
+
+  def fold[A](move: Move => A, drop: Drop => A): A =
+    md match
+      case m: Move => move(m)
+      case d: Drop => drop(d)
+
+  def applyVariantEffect: MoveOrDrop =
+    md match
+      case m: Move => m.applyVariantEffect
+      case d: Drop => d
+
+  def toUci: Uci =
+    md match
+      case m: Move => m.toUci
+      case d: Drop => d.toUci

--- a/src/main/scala/MoveOrDrop.scala
+++ b/src/main/scala/MoveOrDrop.scala
@@ -4,21 +4,25 @@ import chess.format.Uci
 
 type MoveOrDrop = Move | Drop
 
-extension (md: MoveOrDrop)
-  def isMove = md.isInstanceOf[Move]
-  def isDrop = md.isInstanceOf[Drop]
+object MoveOrDrop:
+  extension (md: MoveOrDrop)
+    def isMove = md.isInstanceOf[Move]
+    def isDrop = md.isInstanceOf[Drop]
 
-  def fold[A](move: Move => A, drop: Drop => A): A =
-    md match
-      case m: Move => move(m)
-      case d: Drop => drop(d)
+    def fold[A](move: Move => A, drop: Drop => A): A =
+      md match
+        case m: Move => move(m)
+        case d: Drop => drop(d)
 
-  def applyVariantEffect: MoveOrDrop =
-    md match
-      case m: Move => m.applyVariantEffect
-      case d: Drop => d
+    def move: Option[Move] = md.fold(Some(_), _ => None)
+    def drop: Option[Drop] = md.fold(_ => None, Some(_))
 
-  def toUci: Uci =
-    md match
-      case m: Move => m.toUci
-      case d: Drop => d.toUci
+    def applyVariantEffect: MoveOrDrop =
+      md match
+        case m: Move => m.applyVariantEffect
+        case d: Drop => d
+
+    def toUci: Uci =
+      md match
+        case m: Move => m.toUci
+        case d: Drop => d.toUci

--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -7,6 +7,7 @@ import cats.syntax.all.*
 import chess.format.pgn.{ Parser, Reader, San, SanStr, Tag, Tags }
 import chess.format.{ Fen, Uci }
 import chess.variant.Variant
+import MoveOrDrop.*
 
 case class Replay(setup: Game, moves: List[MoveOrDrop], state: Game):
 

--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -10,11 +10,11 @@ import chess.variant.Variant
 
 case class Replay(setup: Game, moves: List[MoveOrDrop], state: Game):
 
-  lazy val chronoMoves = moves.reverse
+  lazy val chronoMoves: List[MoveOrDrop] = moves.reverse
 
   def addMove(moveOrDrop: MoveOrDrop) =
     copy(
-      moves = moveOrDrop.left.map(_.applyVariantEffect) :: moves,
+      moves = moveOrDrop.applyVariantEffect :: moves,
       state = moveOrDrop.fold(state.apply, state.applyDrop)
     )
 

--- a/src/main/scala/format/Uci.scala
+++ b/src/main/scala/format/Uci.scala
@@ -31,7 +31,7 @@ object Uci:
 
     def origDest = orig -> dest
 
-    def apply(situation: Situation) = situation.move(orig, dest, promotion) map Left.apply
+    def apply(situation: Situation) = situation.move(orig, dest, promotion)
 
     override def toString = s"Move(${orig.key}${dest.key}${promotion.fold("")(_.forsyth)})"
 
@@ -66,7 +66,7 @@ object Uci:
 
     def origDest = pos -> pos
 
-    def apply(situation: Situation) = situation.drop(role, pos) map Right.apply
+    def apply(situation: Situation) = situation.drop(role, pos)
 
   object Drop:
 

--- a/src/main/scala/format/UciDump.scala
+++ b/src/main/scala/format/UciDump.scala
@@ -22,11 +22,11 @@ object UciDump:
 
   def move(variant: Variant, force960Notation: Boolean = false)(mod: MoveOrDrop): String =
     mod match
-      case Left(m) =>
+      case m: Move =>
         Move.Castle.raw(m.castle).fold(m.toUci.uci) {
           case ((kf, kt), (rf, _))
               if force960Notation || kf == kt || variant.chess960 || variant.fromPosition =>
             kf.key + rf.key
           case ((kf, kt), _) => kf.key + kt.key
         }
-      case Right(d) => d.toUci.uci
+      case d: Drop => d.toUci.uci

--- a/src/main/scala/format/pgn/parsingModel.scala
+++ b/src/main/scala/format/pgn/parsingModel.scala
@@ -45,7 +45,7 @@ case class Std(
     metas: Metas = Metas.empty
 ) extends San:
 
-  def apply(situation: Situation) = move(situation) map Left.apply
+  def apply(situation: Situation) = move(situation)
 
   override def withSuffixes(s: Suffixes) =
     copy(
@@ -81,7 +81,7 @@ case class Drop(
     metas: Metas = Metas.empty
 ) extends San:
 
-  def apply(situation: Situation) = drop(situation) map Right.apply
+  def apply(situation: Situation) = drop(situation)
 
   def withMetas(m: Metas) = copy(metas = m)
 
@@ -121,7 +121,7 @@ case class Castle(
     metas: Metas = Metas.empty
 ) extends San:
 
-  def apply(situation: Situation) = move(situation) map Left.apply
+  def apply(situation: Situation) = move(situation)
 
   def withMetas(m: Metas) = copy(metas = m)
 

--- a/src/main/scala/opening/OpeningDb.scala
+++ b/src/main/scala/opening/OpeningDb.scala
@@ -46,13 +46,13 @@ object OpeningDb:
 
   def search(replay: Replay): Option[Opening.AtPly] =
     searchInSituations {
-      val moves = replay.chronoMoves.view
+      val moves: Vector[Move] = replay.chronoMoves.view
         .take(SEARCH_MAX_PLIES)
         .takeWhile {
-          case Left(move) => move.situationBefore.board.nbPieces >= SEARCH_MIN_PIECES
+          case move: Move => move.situationBefore.board.nbPieces >= SEARCH_MIN_PIECES
           case _          => false
         }
-        .collect { case Left(move) => move }
+        .collect { case move: Move => move }
         .toVector
       moves.map(_.situationBefore) ++ moves.lastOption.map(_.situationAfter).toVector
     }

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -11,5 +11,3 @@ type Direction  = Pos => Option[Pos]
 type Directions = List[Direction]
 
 type PieceMap = Map[Pos, Piece]
-
-type MoveOrDrop = Either[Move, Drop]

--- a/src/test/scala/DividerTest.scala
+++ b/src/test/scala/DividerTest.scala
@@ -2,6 +2,7 @@ package chess
 
 import scala.language.implicitConversions
 import org.specs2.matcher.MustMatchers.akaMust
+import MoveOrDrop.*
 
 class DividerTest extends ChessTest:
 

--- a/src/test/scala/format/pgn/ReaderTest.scala
+++ b/src/test/scala/format/pgn/ReaderTest.scala
@@ -2,6 +2,7 @@ package chess
 package format.pgn
 
 import scala.language.implicitConversions
+import MoveOrDrop.*
 
 class ReaderTest extends ChessTest:
 

--- a/src/test/scala/format/pgn/ReaderTest.scala
+++ b/src/test/scala/format/pgn/ReaderTest.scala
@@ -151,8 +151,8 @@ class ReaderTest extends ChessTest:
   }
   "exotic notation from clono.no" in {
     Reader.full(clonoNoExoticNotation) must beValid.like { case Complete(replay) =>
-      replay.chronoMoves lift 42 must beSome {
-        (_: MoveOrDrop) must beLeft { (_: chess.Move).toUci.uci must_== "e7f8q" }
+      replay.chronoMoves lift 42 must beSome { (m: MoveOrDrop) =>
+        m.toUci.uci must_== "e7f8q"
       }
     }
   }


### PR DESCRIPTION
Refactor `type MoveOrDrop = Either[Move, Drop]` to `type MoveOrDrop = Move | Drop`.
