### PR TITLE
Use intersects/isDisjoint instead of sharedAny/sharedNone

### DIFF
--- a/bench/src/main/scala/benchmarks/ParserBench.scala
+++ b/bench/src/main/scala/benchmarks/ParserBench.scala
@@ -11,9 +11,9 @@ import chess.format.pgn.Parser
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Measurement(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 3)
-@Warmup(iterations = 3, timeUnit = TimeUnit.SECONDS, time = 3)
-@Fork(2)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Threads(value = 1)
 class ParserBench {
 
   var games = Fixtures.gamesForPerfTest

--- a/bench/src/main/scala/benchmarks/PerftBench.scala
+++ b/bench/src/main/scala/benchmarks/PerftBench.scala
@@ -10,9 +10,9 @@ import chess.variant.*
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Measurement(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 3)
-@Warmup(iterations = 3, timeUnit = TimeUnit.SECONDS, time = 3)
-@Fork(2)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Threads(value = 1)
 class PerftBench {
 
   var threecheckPerfts = Perft.threeCheckPerfts

--- a/bench/src/main/scala/benchmarks/PlayBench.scala
+++ b/bench/src/main/scala/benchmarks/PlayBench.scala
@@ -15,9 +15,9 @@ import chess.{Mode => _ , *}
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Measurement(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 3)
-@Warmup(iterations = 3, timeUnit = TimeUnit.SECONDS, time = 3)
-@Fork(2)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Threads(value = 1)
 class PlayBench:
 
   var standard = Game(Board init chess.variant.Standard, White)

--- a/src/main/scala/Castles.scala
+++ b/src/main/scala/Castles.scala
@@ -11,7 +11,7 @@ object Castles extends OpaqueBitboard[Castles]:
 
   extension (c: Castles)
 
-    inline def can(inline color: Color): Boolean           = c.sharedAny(Bitboard.rank(color.backRank))
+    inline def can(inline color: Color): Boolean           = c.intersects(Bitboard.rank(color.backRank))
     inline def can(inline color: Color, inline side: Side) = c.contains(color.at(side))
 
     def whiteKingSide: Boolean  = c.contains(H1)

--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -276,7 +276,7 @@ case class Situation(board: Board, color: Color):
             if board.variant.chess960 || board.variant.fromPosition
             then (Bitboard.between(king, rook) | Bitboard.between(king, kingTo))
             else Bitboard.between(king, rook)
-          if path.sharedNone(board.occupied, ~rook.bb)
+          if (path & board.occupied & ~rook.bb).isEmpty
           kingPath = Bitboard.between(king, kingTo) | king.bb
           if kingPath.occupiedSquares.forall(board.variant.castleCheckSafeSquare(this, king, _))
           moves <- castle(king, kingTo, rook, rookTo)

--- a/src/main/scala/UnmovedRooks.scala
+++ b/src/main/scala/UnmovedRooks.scala
@@ -26,7 +26,7 @@ object UnmovedRooks extends OpaqueBitboard[UnmovedRooks]:
     // If there are two rooks on the same rank, return the side of the rook
     def side(pos: Pos): Option[Option[Side]] =
       val rook = pos.bb
-      if ur.sharedNone(rook) then None
+      if ur.isDisjoint(rook) then None
       else
         (ur & ~rook & Bitboard.rank(pos.rank)).first match
           case Some(otherRook) =>

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -52,10 +52,6 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
     // remove the first non empty position
     def removeFirst: A = (a.value & (a.value - 1L)).bb
 
-    // check if the intersection of all bitboards is not empty
-    def sharedAny(o: Long, xs: Long*): Boolean =
-      (a & xs.foldLeft(o)(_ & _)).nonEmpty
-
     def intersects(o: Long): Boolean =
       (a.value & o) != 0L
 
@@ -67,16 +63,6 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
 
     def isDisjoint[B](o: B)(using sr: BitboardRuntime[B]): Boolean =
       (a & sr(o)).isEmpty
-
-    // check if the intersection of all bitboards is not empty
-    def sharedAny[B](o: B, xs: B*)(using sr: BitboardRuntime[B]): Boolean =
-      (a & xs.foldLeft(sr(o))(_ & sr(_))).nonEmpty
-
-    // check if the intersection of all bitboards is empty
-    def sharedNone(o: Long, xs: Long*): Boolean = !sharedAny(o, xs*)
-
-    // check if the intersection of all bitboards is empty
-    def sharedNone[B](o: B, xs: B*)(using BitboardRuntime[B]): Boolean = !sharedAny(o, xs*)
 
     def fold[B](init: B)(f: (B, Pos) => B): B =
       var b      = a.value

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -56,6 +56,18 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
     def sharedAny(o: Long, xs: Long*): Boolean =
       (a & xs.foldLeft(o)(_ & _)).nonEmpty
 
+    def intersects(o: Long): Boolean =
+      (a.value & o) != 0L
+
+    def intersects[B](o: B)(using sr: BitboardRuntime[B]): Boolean =
+      (a & sr(o)).nonEmpty
+
+    def isDisjoint(o: Long): Boolean =
+      (a & o).isEmpty
+
+    def isDisjoint[B](o: B)(using sr: BitboardRuntime[B]): Boolean =
+      (a & sr(o)).isEmpty
+
     // check if the intersection of all bitboards is not empty
     def sharedAny[B](o: B, xs: B*)(using sr: BitboardRuntime[B]): Boolean =
       (a & xs.foldLeft(sr(o))(_ & sr(_))).nonEmpty

--- a/src/main/scala/variant/Atomic.scala
+++ b/src/main/scala/variant/Atomic.scala
@@ -37,7 +37,7 @@ case object Atomic
     import board.board.{ byColor, kings }
     val theirKings = byColor(!color) & kings
     kings(color).exists { k =>
-      k.kingAttacks.sharedNone(theirKings) && attackersWithoutKing(
+      k.kingAttacks.isDisjoint(theirKings) && attackersWithoutKing(
         board,
         board.board.occupied,
         k,
@@ -68,7 +68,7 @@ case object Atomic
     // In Atomic, when the kings are connected, checks do not apply
     import situation.board.board.{ byColor, kings }
     val theirKings = byColor(!situation.color) & kings
-    kingTo.kingAttacks.sharedAny(theirKings) || attackersWithoutKing(
+    kingTo.kingAttacks.intersects(theirKings) || attackersWithoutKing(
       situation.board,
       (situation.board.occupied ^ kingFrom.bb),
       kingTo,

--- a/src/main/scala/variant/KingOfTheHill.scala
+++ b/src/main/scala/variant/KingOfTheHill.scala
@@ -18,7 +18,7 @@ case object KingOfTheHill
   private val center = 0x1818000000L
 
   override def specialEnd(situation: Situation) =
-    situation.board.kingPosOf(!situation.color).sharedAny(center)
+    situation.board.kingPosOf(!situation.color).intersects(center)
 
   /** You only need a king to be able to win in this variant
     */

--- a/src/main/scala/variant/RacingKings.scala
+++ b/src/main/scala/variant/RacingKings.scala
@@ -47,7 +47,7 @@ case object RacingKings
   override def opponentHasInsufficientMaterial(situation: Situation) = false
 
   private def reachedGoal(board: Board, color: Color) =
-    board.kingPosOf(color).sharedAny(Bitboard.rank(Rank.Eighth))
+    board.kingPosOf(color).intersects(Bitboard.rank(Rank.Eighth))
 
   private def reachesGoal(move: Move) =
     reachedGoal(move.situationAfter.board, move.piece.color)

--- a/src/main/scala/variant/Variant.scala
+++ b/src/main/scala/variant/Variant.scala
@@ -146,10 +146,10 @@ abstract class Variant private[variant] (
   @nowarn def finalizeBoard(board: Board, uci: format.Uci, captured: Option[Piece]): Board = board
 
   protected def pawnsOnPromotionRank(board: Board, color: Color) =
-    board(color, Pawn).sharedAny(Bitboard.rank(color.promotablePawnRank))
+    board(color, Pawn).intersects(Bitboard.rank(color.promotablePawnRank))
 
   protected def pawnsOnBackRank(board: Board, color: Color) =
-    board(color, Pawn).sharedAny(Bitboard.rank(color.backRank))
+    board(color, Pawn).intersects(Bitboard.rank(color.backRank))
 
   protected def validSide(board: Board, strict: Boolean)(color: Color) =
     board(color, King).count == 1 &&

--- a/src/test/scala/bitboard/Fen.scala
+++ b/src/test/scala/bitboard/Fen.scala
@@ -26,8 +26,8 @@ case class Fen(board: Board, state: State):
         result
       case Move.EnPassant(from, to) =>
         val newOccupied = (occupied ^ from.bb ^ to.withRankOf(from).bb) | to.bb
-        king.rookAttacks(newOccupied).sharedNone(them, (board.rooks ^ board.queens)) &&
-        king.bishopAttacks(newOccupied).sharedNone(them, (board.bishops ^ board.queens))
+        (king.rookAttacks(newOccupied) & them & (board.rooks ^ board.queens)).isEmpty &&
+        (king.bishopAttacks(newOccupied) & them & (board.bishops ^ board.queens)).isEmpty
       case _ => true
 
   // TODO now it works with valid move only

--- a/src/test/scala/bitboard/OpaqueBitboardTest.scala
+++ b/src/test/scala/bitboard/OpaqueBitboardTest.scala
@@ -80,27 +80,17 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
     }
   }
 
-  test("sharedAny should be true when the two bitboards have at least one common square") {
+  test("intersects should be true when the two bitboards have at least one common square") {
     forAll { (b1: Bitboard, b2: Bitboard, p: Pos) =>
-      b1.addPos(p).sharedAny(b2.addPos(p))
+      b1.addPos(p).intersects(b2.addPos(p))
     }
   }
 
-  test("sharedAny and intersection should be consistent") {
+  test("intersects and set intersection should be consistent") {
     forAll { (s1: Set[Pos], s2: Set[Pos]) =>
       val b1 = Bitboard(s1)
       val b2 = Bitboard(s2)
       val s  = s1 intersect s2
-      b1.sharedAny(b2) == s.nonEmpty
-    }
-  }
-
-  test("sharedAny and intersection should be consistent") {
-    forAll { (s1: Set[Pos], s2: Set[Pos], xs: List[Set[Pos]]) =>
-      val b1 = Bitboard(s1)
-      val b2 = Bitboard(s2)
-      val s  = s1.intersect(xs.foldLeft(s2)(_ intersect _))
-      val bs = xs.map(Bitboard(_))
-      b1.sharedAny(b2, bs*) == s.nonEmpty
+      b1.intersects(b2) == s.nonEmpty
     }
   }

--- a/src/test/scala/bitboard/OpaqueBitboardTest.scala
+++ b/src/test/scala/bitboard/OpaqueBitboardTest.scala
@@ -102,9 +102,7 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
   }
 
   test("isDisjoint and intersects always return the opposite value") {
-    forAll { (s1: Set[Pos], s2: Set[Pos]) =>
-      val b1 = Bitboard(s1)
-      val b2 = Bitboard(s2)
+    forAll { (b1: Bitboard, b2: Bitboard) =>
       b1.isDisjoint(b2) == !b1.intersects(b2)
     }
   }

--- a/src/test/scala/bitboard/OpaqueBitboardTest.scala
+++ b/src/test/scala/bitboard/OpaqueBitboardTest.scala
@@ -94,3 +94,17 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
       b1.intersects(b2) == s.nonEmpty
     }
   }
+
+  test("isDisjoint should be false when the two bitboards have at least common square") {
+    forAll { (b1: Bitboard, b2: Bitboard, p: Pos) =>
+      !b1.addPos(p).isDisjoint(b2.addPos(p))
+    }
+  }
+
+  test("isDisjoint and intersects always return the opposite value") {
+    forAll { (s1: Set[Pos], s2: Set[Pos]) =>
+      val b1 = Bitboard(s1)
+      val b2 = Bitboard(s2)
+      b1.isDisjoint(b2) == !b1.intersects(b2)
+    }
+  }


### PR DESCRIPTION
Did run benchmarking and the result is as @niklasf predicted, `sharedAny` and `sharedNone` are much slower than `&`.

Here is the benchmark result: https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/lenguyenthanh/e5b1eb149ccbbea7b4b9a928f4194fdf/raw/57eca9c682ff40887ac4127777f8badf51558bfd/master-230218.json,https://gist.githubusercontent.com/lenguyenthanh/e5b1eb149ccbbea7b4b9a928f4194fdf/raw/57eca9c682ff40887ac4127777f8badf51558bfd/intersects.json
