### PR TITLE
Improve atomic's exploding with bitboard

### DIFF
--- a/src/main/scala/Board.scala
+++ b/src/main/scala/Board.scala
@@ -83,7 +83,7 @@ case class Board(
       b3 <- b2.place(pawn.color.queen, pos)
     yield b3
 
-  def castles: Castles = history.castles
+  export history.{ castles, unmovedRooks }
 
   def withHistory(h: History): Board = copy(history = h)
 
@@ -103,8 +103,6 @@ case class Board(
     withCrazyData(f(crazyData | Crazyhouse.Data.init))
 
   def ensureCrazyData: Board = withCrazyData(crazyData | Crazyhouse.Data.init)
-
-  def unmovedRooks = history.unmovedRooks
 
   inline def updateHistory(inline f: History => History) = copy(history = f(history))
 

--- a/src/main/scala/Pos.scala
+++ b/src/main/scala/Pos.scala
@@ -33,7 +33,9 @@ object Pos extends OpaqueInt[Pos]:
     def <->(other: Pos): Iterable[Pos] =
       min(file.value, other.file.value) to max(file.value, other.file.value) flatMap { Pos.at(_, rank.value) }
 
-    inline def touches(other: Pos): Boolean = xDist(other) <= 1 && yDist(other) <= 1
+    inline def touches(other: Pos): Boolean =
+      import bitboard.Bitboard.*
+      p.kingAttacks.contains(other)
 
     inline def onSameDiagonal(other: Pos): Boolean =
       file.value - rank.value == other.file.value - other.rank.value || file.value + rank.value == other.file.value + other.rank.value

--- a/src/main/scala/bitboard/Board.scala
+++ b/src/main/scala/bitboard/Board.scala
@@ -118,6 +118,20 @@ case class Board(
       )
     }
 
+  def discard(mask: Bitboard): Board =
+    val notMask = ~mask
+    copy(
+      pawns = pawns & notMask,
+      knights = knights & notMask,
+      bishops = bishops & notMask,
+      rooks = rooks & notMask,
+      queens = queens & notMask,
+      kings = kings & notMask,
+      white = white & notMask,
+      black = black & notMask,
+      occupied & notMask
+    )
+
   def updateRole(mask: Bitboard, role: Role): Role => Bitboard =
     case Pawn if role == Pawn     => pawns ^ mask
     case Knight if role == Knight => knights ^ mask

--- a/src/main/scala/bitboard/Board.scala
+++ b/src/main/scala/bitboard/Board.scala
@@ -101,22 +101,8 @@ case class Board(
       bs.fold(Bitboard.empty)((a, b) => a | b)
     }
 
-  // todo more efficient
   def discard(s: Pos): Board =
-    pieceAt(s).fold(this) { p =>
-      val m = s.bb
-      copy(
-        pawns = updateRole(m, Pawn)(p.role),
-        knights = updateRole(m, Knight)(p.role),
-        bishops = updateRole(m, Bishop)(p.role),
-        rooks = updateRole(m, Rook)(p.role),
-        queens = updateRole(m, Queen)(p.role),
-        kings = updateRole(m, King)(p.role),
-        white = updateColor(m, Color.White)(p.color),
-        black = updateColor(m, Color.Black)(p.color),
-        occupied ^ m
-      )
-    }
+    discard(s.bb)
 
   def discard(mask: Bitboard): Board =
     val notMask = ~mask

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -226,8 +226,8 @@ class AtomicVariantTest extends ChessTest:
       validGame must beValid.like { case game =>
         game.board(Pos.E6) must beNone // The pawn that captures during en-passant should explode
         // Every piece surrounding the en-passant destination square that is not a pawn should be empty
-        Atomic
-          .surroundingPositions(Pos.E6)
+        import bitboard.Bitboard.*
+        Pos.E6.kingAttacks.occupiedSquares
           .forall(pos => game.board(pos).isEmpty || pos == Pos.E7 || pos == Pos.D7) must beTrue
       }
     }
@@ -633,6 +633,15 @@ class AtomicVariantTest extends ChessTest:
       val game      = fenToGame(position, Atomic)
       val errorGame = game flatMap (_.playMove(Pos.E1, Pos.B1))
       errorGame must beInvalid
+    }
+
+    "Exploded rooks can't castle" in {
+      val position = EpdFen("1r2k3/8/8/8/8/8/1P6/1R2K3 b Q - 0 1")
+      val game     = fenToGame(position, Atomic)
+      val newGame  = game flatMap (_.playMove(Pos.B8, Pos.B2))
+      newGame must beValid.like { case game =>
+        game.situation.legalMoves.filter(_.castles) must beEmpty
+      }
     }
 
   }


### PR DESCRIPTION
More improvements for Atomic exploding and `bitboard.Board.discard` function.

Here is the [benchmark result](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/lenguyenthanh/ea7f027f5aef45fe6716ba26cc535fa5/raw/f15cc416cd8feb964469c70a761dc2885a18b8cb/master-aeb00a0.json,https://gist.githubusercontent.com/lenguyenthanh/ea7f027f5aef45fe6716ba26cc535fa5/raw/f15cc416cd8feb964469c70a761dc2885a18b8cb/atomic.json) against current master.

<img width="389" alt="Screenshot 2023-02-24 at 14 22 20" src="https://user-images.githubusercontent.com/437967/221189170-3bc27910-e922-4cf8-b7f5-de67e6ac5cb4.png">

