### PR TITLE
Horde: Black insufficient material bug

### DIFF
--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -49,12 +49,15 @@ case object Horde
     * nor does it consider contrived fortresses such as b7/pk6/P7/P7/8/8/8/8 b - -
     */
   private def hordeClosedPosition(board: Board) =
-    def notKingBoard = board.board.kings(Color.black).headOption.flatMap(board.take) | board
-    val hordePos     = board.occupation(Color.white) // may include promoted pieces
+    def hasLegalMovesWithoutKing(situation: Situation): Boolean =
+      val legalMoves = validMoves(situation)
+      if situation.isWhiteTurn then legalMoves.isEmpty
+      else legalMoves.filter(_.piece.role != King).isEmpty
+
+    val hordePos = board.occupation(Color.white) // may include promoted pieces
     val mateInOne =
       hordePos.sizeIs == 1 && hordePos.forall(pos => pieceThreatened(board, Color.black, pos))
-    !mateInOne && Color.all.map(Situation(notKingBoard, _)).forall(_.legalMoves.isEmpty)
-    // !mateInOne && notKingBoard.actors.values.forall(actor => actor.moves.isEmpty)
+    !mateInOne && Color.all.map(board.situationOf(_)).forall(hasLegalMovesWithoutKing)
 
   /** In horde chess, black can win unless a fortress stalemate is unavoidable.
     *  Auto-drawing the game should almost never happen, but it did in https://lichess.org/xQ2RsU8N#121
@@ -70,7 +73,7 @@ case object Horde
     val board         = situation.board
     val opponentColor = !situation.color
     lazy val fortress = hordeClosedPosition(board) // costly function call
-    if (opponentColor == Color.white)
+    if opponentColor == Color.white then
       lazy val notKingPieces           = InsufficientMatingMaterial.nonKingPieces(board) toList
       val horde                        = board.piecesOf(Color.white)
       lazy val hordeBishopSquareColors = horde.filter(_._2.is(Bishop)).toList.map(_._1.isLight).distinct

--- a/src/main/scala/variant/Horde.scala
+++ b/src/main/scala/variant/Horde.scala
@@ -34,7 +34,7 @@ case object Horde
 
   def validMoves(situation: Situation): List[Move] =
     import situation.{ genEnPassant, genNonKing, isWhiteTurn, us, board }
-    if isWhiteTurn then genEnPassant(us & board.pawns) ++ genNonKing(~us)
+    if isWhiteTurn then genEnPassant(us & board.pawns) ++ genNonKing(~us & ~board.kings)
     else Standard.validMoves(situation)
 
   override def valid(board: Board, strict: Boolean) =

--- a/src/test/scala/HordeVariantTest.scala
+++ b/src/test/scala/HordeVariantTest.scala
@@ -91,6 +91,15 @@ class HordeVariantTest extends ChessTest:
       }
     }
 
+    "Must not be insufficient winning material for king with queen and rook left" in {
+      val position = EpdFen("8/5k2/7q/7P/6rP/6P1/6P1/8 b - - 0 52")
+      val game     = fenToGame(position, Horde)
+
+      game must beValid.like { case game =>
+        game.situation.opponentHasInsufficientMaterial must beFalse
+      }
+    }
+
     "Must auto-draw in simple pawn fortress" in {
       val position = EpdFen("8/p7/pk6/P7/P7/8/8/8 b - -")
       val game     = fenToGame(position, Horde)

--- a/src/test/scala/HordeVariantTest.scala
+++ b/src/test/scala/HordeVariantTest.scala
@@ -121,6 +121,16 @@ class HordeVariantTest extends ChessTest:
       }
     }
 
+    "Must auto-draw if horde is stalemated and only king can move" in {
+      val position = EpdFen("b7/pk6/P7/P7/8/8/8/8 b - - 0 1")
+      val game     = fenToGame(position, Horde)
+
+      game must beValid.like { case game =>
+        game.situation.autoDraw must beTrue
+        game.situation.opponentHasInsufficientMaterial must beTrue
+      }
+    }
+
     "Must not auto-draw in B vs K endgame, king can win" in {
       val position = EpdFen("7B/6k1/8/8/8/8/8/8 b - -")
       val game     = fenToGame(position, Horde)
@@ -169,7 +179,7 @@ class HordeVariantTest extends ChessTest:
       val newGame  = game.flatMap(_.apply(Pos.H8, Pos.H6))
       newGame must beValid.like { case game =>
         game._1.situation.board.history.unmovedRooks must_== UnmovedRooks(Set(Pos.A8))
-        game._1.situation.board.history.castles.pp must_== Castles("q")
+        game._1.situation.board.history.castles must_== Castles("q")
       }
     }
 

--- a/src/test/scala/HordeVariantTest.scala
+++ b/src/test/scala/HordeVariantTest.scala
@@ -97,6 +97,7 @@ class HordeVariantTest extends ChessTest:
 
       game must beValid.like { case game =>
         game.situation.opponentHasInsufficientMaterial must beFalse
+        game.situation.autoDraw must beFalse
       }
     }
 


### PR DESCRIPTION
Reported by https://lichess.org/forum/lichess-feedback/horde-game-declared-a-draw-moves-still-possible
And thanks @370417 for the test and investigation.

I did cause this bug via: #372, specially these lines: https://github.com/lichess-org/scalachess/blob/master/src/main/scala/variant/Standard.scala#L23-L24

There is a hidden breaking changes in moves generator. Not it requires the King on the board in order to generate legal moves (which is makes sense imho). But that created the current bug.

Previously, in [hordeClosedPosition](https://github.com/lichess-org/scalachess/pull/375/commits/ed4707cbd305fa3b8fa1763de15e150710d00a35#diff-68b609c46c14d44b7611d95a53be1a8ebefb9c5bff8ef449ef42cfdc15669709R51) function, it removes the King from the board and then tries to generate legalMoves, which is always empty now because there is no King on the board anymore. So, what we do instead is finding all legal moves and then filter out all King's moves.

Another change is excluding Black's King from the mask when genNonKing. This is necessary for `hordeClosedPosition` function to works, because otherwise if Black was in checked, White always have a "valid" move which is capturing the Black's King. 