### PR TITLE
Optimize replay & Opaque type for Sans & Bump 14.5.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val scalachess = Project("scalachess", file(".")).settings(
 )
 
 ThisBuild / organization           := "org.lichess"
-ThisBuild / version                := "14.5.4"
+ThisBuild / version                := "14.5.6"
 ThisBuild / scalaVersion           := "3.2.2"
 ThisBuild / licenses += "AGPL-3.0" -> url("https://opensource.org/licenses/AGPL-3.0")
 

--- a/src/main/scala/Piece.scala
+++ b/src/main/scala/Piece.scala
@@ -26,17 +26,6 @@ case class Piece(color: Color, role: Role):
       case Knight => from.knightAttacks.contains(to)
       case Pawn   => from.pawnAttacks(color).contains(to)
 
-  // movable positions assuming empty board
-  def eyesMovable(from: Pos, to: Pos): Boolean =
-    if (role == Pawn) Piece.pawnEyes(color, from, to) || {
-      (from ?| to) && {
-        val dy = to.rank.value - from.rank.value
-        if (color.white) (dy == 1 || (from.rank <= Rank.Second && dy == 2))
-        else (dy == -1 || (from.rank >= Rank.Seventh && dy == -2))
-      }
-    }
-    else eyes(from, to)
-
   override def toString = s"$color-$role".toLowerCase
 
 object Piece:
@@ -44,9 +33,4 @@ object Piece:
   def fromChar(c: Char): Option[Piece] =
     Role.allByPgn get c.toUpper map {
       Piece(Color.fromWhite(c.isUpper), _)
-    }
-
-  private def pawnEyes(color: Color, from: Pos, to: Pos) =
-    (from xDist to) == 1 && (to.rank.value - from.rank.value) == {
-      if (color.white) 1 else -1
     }

--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -31,9 +31,10 @@ object Replay:
       initialFen: Option[Fen.Epd],
       variant: Variant
   ): Validated[ErrorStr, Reader.Result] =
-    sans.some.filter(_.nonEmpty).toValid(ErrorStr("[replay] pgn is empty")).andThen { nonEmptyMoves =>
+    if sans.isEmpty then ErrorStr("[replay] pgn is empty").invalid
+    else
       Reader.moves(
-        nonEmptyMoves,
+        sans,
         Tags(
           List(
             initialFen map { fen =>
@@ -45,7 +46,6 @@ object Replay:
           ).flatten
         )
       )
-    }
 
   private def computeGames(game: Game, sans: List[San]): Validated[ErrorStr, List[Game]] =
     sans

--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -5,6 +5,7 @@ import cats.data.Validated.{ invalid, valid }
 import cats.syntax.all.*
 
 import chess.format.pgn.{ Parser, Reader, San, SanStr, Tag, Tags }
+import chess.format.pgn.Sans.*
 import chess.format.{ Fen, Uci }
 import chess.variant.Variant
 import MoveOrDrop.*

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -67,7 +67,7 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
     def first[B](f: Pos => Option[B]): Option[B] =
       var b                 = a.value
       var result: Option[B] = None
-      while b != 0L || result.isDefined
+      while b != 0L && result.isEmpty
       do
         result = f(b.lsb.get)
         b &= (b - 1L)

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -64,6 +64,15 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
     def isDisjoint[B](o: B)(using sr: BitboardRuntime[B]): Boolean =
       (a & sr(o)).isEmpty
 
+    def first[B](f: Pos => Option[B]): Option[B] =
+      var b                 = a.value
+      var result: Option[B] = None
+      while b != 0L || result.isDefined
+      do
+        result = f(b.lsb.get)
+        b &= (b - 1L)
+      result
+
     def fold[B](init: B)(f: (B, Pos) => B): B =
       var b      = a.value
       var result = init

--- a/src/main/scala/format/pgn/parsingModel.scala
+++ b/src/main/scala/format/pgn/parsingModel.scala
@@ -4,16 +4,18 @@ package format.pgn
 import cats.data.Validated
 import cats.syntax.option.*
 
+opaque type Sans = List[San]
+object Sans:
+  val empty                        = Nil
+  def apply(sans: List[San]): Sans = sans
+
+  extension (sans: Sans) def value: List[San] = sans
+
 case class ParsedPgn(
     initialPosition: InitialPosition,
     tags: Tags,
     sans: Sans
 )
-
-case class Sans(value: List[San]) extends AnyVal
-
-object Sans:
-  val empty = Sans(Nil)
 
 // Standard Algebraic Notation
 sealed trait San:

--- a/src/main/scala/format/pgn/parsingModel.scala
+++ b/src/main/scala/format/pgn/parsingModel.scala
@@ -127,7 +127,7 @@ case class Castle(
         .applyVariantEffect(genCastling(k))
         .filter(variant.kingSafety)
         .find(_.castle.exists(_.side == side))
-    ) toValid ErrorStr(s"Cannot castle / variant is ${situation.board.variant}")
+    ) toValid ErrorStr(s"Cannot castle / variant is $variant")
 
 case class Suffixes(
     check: Boolean,

--- a/src/test/scala/AntichessVariantTest.scala
+++ b/src/test/scala/AntichessVariantTest.scala
@@ -378,7 +378,6 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
     }
 
     "fen with castles" in {
-      println("fen with castles")
       val game = fenToGame(EpdFen("rnbqk2r/ppppppbp/5np1/8/8/5NP1/PPPPPPBP/RNBQK2R w KQkq - 4 4"), Antichess)
 
       game must beValid.like { case game =>

--- a/src/test/scala/ReplayTest.scala
+++ b/src/test/scala/ReplayTest.scala
@@ -93,6 +93,14 @@ class ReplayTest extends ChessTest:
     }
   }
 
+  "Castling should not be possible when in check" in {
+    val fen   = EpdFen("r1bq1rk1/ppp2ppp/2n5/8/1bB1Pp2/5N2/PPP1Q1PP/R1B1K2R w KQ - 1 10")
+    val moves = List(SanStr("O-O"))
+    Replay.gameMoveWhileValid(moves, fen, variant.Standard) must beLike { case (_, games, Some(_)) =>
+      games.size must_== 0
+    }
+  }
+
   "replay from standard positions" in {
     val nb    = 500
     val games = Fixtures.prod500standard

--- a/src/test/scala/ReplayTest.scala
+++ b/src/test/scala/ReplayTest.scala
@@ -4,6 +4,7 @@ import cats.syntax.option.*
 import format.{ EpdFen, Fen, Uci }
 import chess.format.pgn.SanStr
 import chess.variant.Chess960
+import chess.format.pgn.Fixtures
 
 class ReplayTest extends ChessTest:
 
@@ -89,5 +90,19 @@ class ReplayTest extends ChessTest:
     val moves = List(SanStr("c4"))
     Replay.gameMoveWhileValid(moves, fen, variant.Antichess) must beLike { case (_, games, Some(_)) =>
       games.size must_== 0
+    }
+  }
+
+  "replay from standard positions" in {
+    val nb    = 500
+    val games = Fixtures.prod500standard
+    val gameMoves = (games take nb).map { g =>
+      SanStr from g.split(' ').toList
+    }
+    gameMoves forall { moves =>
+      Replay.gameMoveWhileValid(moves, chess.format.Fen.initial, chess.variant.Standard) must beLike {
+        case (_, games, None) =>
+          games.size must_== moves.size
+      }
     }
   }

--- a/src/test/scala/ReplayTest.scala
+++ b/src/test/scala/ReplayTest.scala
@@ -101,6 +101,14 @@ class ReplayTest extends ChessTest:
     }
   }
 
+  "Castling in Antichess is not allowed" in {
+    val fen   = EpdFen("r3kbnr/p3pp1p/1p4p1/8/8/P7/1P1P1PPP/RNB2KNR b - - 0 9")
+    val moves = List(SanStr("O-O-0"))
+    Replay.gameMoveWhileValid(moves, fen, variant.Antichess) must beLike { case (_, games, Some(_)) =>
+      games.size must_== 0
+    }
+  }
+
   "replay from standard positions" in {
     val nb    = 500
     val games = Fixtures.prod500standard

--- a/src/test/scala/bitboard/OpaqueBitboardTest.scala
+++ b/src/test/scala/bitboard/OpaqueBitboardTest.scala
@@ -52,6 +52,24 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
     }
   }
 
+  test("first with a function that always return None should return None") {
+    forAll { (bb: Bitboard) =>
+      assertEquals(bb.first(_ => None), None)
+    }
+  }
+
+  test("first with a function that always return Some should return the first pos") {
+    forAll { (bb: Bitboard) =>
+      assertEquals(bb.first(Some(_)), bb.first)
+    }
+  }
+
+  test("first returns the correct pos") {
+    forAll { (xs: Set[Pos], x: Pos) =>
+      def f = (p: Pos) => if p == x then Some(p) else None
+      Bitboard(xs + x).first(f) == Some(x)
+    }
+  }
   test("bitboard created by set of pos should contains and only contains those pos") {
     forAll { (xs: Set[Pos]) =>
       val bb = Bitboard(xs)

--- a/src/test/scala/format/pgn/ParserTest.scala
+++ b/src/test/scala/format/pgn/ParserTest.scala
@@ -3,6 +3,7 @@ package format.pgn
 
 import cats.syntax.option.*
 import scala.language.implicitConversions
+import Sans.*
 
 class ParserTest extends ChessTest:
 
@@ -124,43 +125,43 @@ class ParserTest extends ChessTest:
       a.metas.glyphs === Glyphs(Glyph.MoveAssessment.dubious.some, None, Nil)
     }
   }
+  extension (sans: Sans) def head = sans.value.head
 
   "nags" in {
     parser(withNag) must beValid
 
-    parser("Ne7g6+! $13") must beValid.like { case ParsedPgn(_, _, Sans(List(san))) =>
-      san.metas.glyphs.move must_== Option(Glyph.MoveAssessment.good)
-      san.metas.glyphs.position must_== Option(Glyph.PositionAssessment.unclear)
+    parser("Ne7g6+! $13") must beValid.like { case ParsedPgn(_, _, sans) =>
+      sans.head.metas.glyphs.move must_== Option(Glyph.MoveAssessment.good)
+      sans.head.metas.glyphs.position must_== Option(Glyph.PositionAssessment.unclear)
     }
   }
 
   "non-nags" in {
     parser(withGlyphAnnotations) must beValid
 
-    parser("Bxd3?? ∞") must beValid.like { case ParsedPgn(_, _, Sans(List(san))) =>
-      san.metas.glyphs.move must_== Option(Glyph.MoveAssessment.blunder)
-      san.metas.glyphs.position must_== Option(Glyph.PositionAssessment.unclear)
+    parser("Bxd3?? ∞") must beValid.like { case ParsedPgn(_, _, sans) =>
+      sans.head.metas.glyphs.move must_== Option(Glyph.MoveAssessment.blunder)
+      sans.head.metas.glyphs.position must_== Option(Glyph.PositionAssessment.unclear)
     }
   }
 
   "comments" in {
-    parser("Ne7g6+! {such a neat comment}") must beValid.like { case ParsedPgn(_, _, Sans(List(san))) =>
-      san.metas.comments must_== List("such a neat comment")
+    parser("Ne7g6+! {such a neat comment}") must beValid.like { case ParsedPgn(_, _, sans) =>
+      sans.head.metas.comments must_== List("such a neat comment")
     }
   }
 
   "variations" in {
-    parser("Ne7g6+! {such a neat comment} (e4 Ng6)") must beValid.like {
-      case ParsedPgn(_, _, Sans(List(san))) =>
-        san.metas.variations.headOption must beSome {
-          (_: Sans).value must haveSize(2)
-        }
+    parser("Ne7g6+! {such a neat comment} (e4 Ng6)") must beValid.like { case ParsedPgn(_, _, sans) =>
+      sans.head.metas.variations.headOption must beSome {
+        (_: Sans).value must haveSize(2)
+      }
     }
   }
 
   "first move variation" in {
-    parser("1. e4 (1. d4)") must beValid.like { case ParsedPgn(_, _, Sans(List(san))) =>
-      san.metas.variations.headOption must beSome {
+    parser("1. e4 (1. d4)") must beValid.like { case ParsedPgn(_, _, sans) =>
+      sans.head.metas.variations.headOption must beSome {
         (_: Sans).value must haveSize(1)
       }
     }


### PR DESCRIPTION
- For Std San: When trying to find the correct moves, traverse only relevant pieces instead of all pieces. Also return result immediately after find the correct move.
- For Castle: Generate only castling moves instead of all legal moves.
- Opaque type for Sans
- Bump 14.5.6

benchmark results: https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/lenguyenthanh/ea7f027f5aef45fe6716ba26cc535fa5/raw/9651d5b58c900cddbe5b60f87faa06b00c2c9d48/master-e422d2d.json,https://gist.githubusercontent.com/lenguyenthanh/ea7f027f5aef45fe6716ba26cc535fa5/raw/971d160c3dc37c9c02203cc74d13f307a1a755a7/replay-2.json

<img width="398" alt="Screenshot 2023-03-02 at 19 57 31" src="https://user-images.githubusercontent.com/437967/222525353-653eb431-0952-4cf1-880f-6a5579d141f0.png">
