### PR TITLE
Some minor simplify and cleanup OpaqueBitboard API

### DIFF
--- a/src/main/scala/Castles.scala
+++ b/src/main/scala/Castles.scala
@@ -26,7 +26,7 @@ object Castles extends OpaqueBitboard[Castles]:
       c & ~color.at(side).bb
 
     def add(color: Color, side: Side): Castles =
-      c.addPos(color.at(side))
+      c.addSquare(color.at(side))
 
     def update(color: Color, kingSide: Boolean, queenSide: Boolean): Castles =
       c.without(color) | kingSide.at(color.kingSide) | queenSide.at(color.queenSide)

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -12,7 +12,7 @@ object InsufficientMatingMaterial:
   // verify if there are at least two bishops of opposite color
   // no matter which sides they are on
   def bishopsOnOppositeColors(board: Board) =
-    board.bishops.occupiedSquares.map(_.isLight).distinct.size == 2
+    board.bishops.squares.map(_.isLight).distinct.size == 2
 
   /*
    * Returns true if a pawn cannot progress forward because it is blocked by a pawn

--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -173,9 +173,9 @@ case class Situation(board: Board, color: Color):
     val capturers = pawns
 
     val s1: List[Move] = for
-      from <- capturers.occupiedSquares
+      from <- capturers.squares
       targets = from.pawnAttacks(color) & them & mask
-      to   <- targets.occupiedSquares
+      to   <- targets.squares
       move <- genPawnMoves(from, to, true)
     yield move
 
@@ -192,13 +192,13 @@ case class Situation(board: Board, color: Color):
          else Bitboard.rank(color.fourthRank))
 
     val s2: List[Move] = for
-      to   <- (singleMoves & mask).occupiedSquares
+      to   <- (singleMoves & mask).squares
       from <- Pos.at(to.value + (if isWhiteTurn then -8 else 8)).toList
       move <- genPawnMoves(from, to, false)
     yield move
 
     val s3: List[Move] = for
-      to   <- (doubleMoves & mask).occupiedSquares
+      to   <- (doubleMoves & mask).squares
       from <- Pos.at(to.value + (if isWhiteTurn then -16 else 16))
       move <- normalMove(from, to, Pawn, false)
     yield move
@@ -207,45 +207,45 @@ case class Situation(board: Board, color: Color):
 
   def genKnight(knights: Bitboard, mask: Bitboard): List[Move] =
     for
-      from <- knights.occupiedSquares
+      from <- knights.squares
       targets = Bitboard.knightAttacks(from) & mask
-      to   <- targets.occupiedSquares
+      to   <- targets.squares
       move <- normalMove(from, to, Knight, isOccupied(to))
     yield move
 
   def genBishop(bishops: Bitboard, mask: Bitboard): List[Move] =
     for
-      from <- bishops.occupiedSquares
+      from <- bishops.squares
       targets = from.bishopAttacks(board.occupied) & mask
-      to   <- targets.occupiedSquares
+      to   <- targets.squares
       move <- normalMove(from, to, Bishop, isOccupied(to))
     yield move
 
   def genRook(rooks: Bitboard, mask: Bitboard): List[Move] =
     for
-      from <- rooks.occupiedSquares
+      from <- rooks.squares
       targets = from.rookAttacks(board.occupied) & mask
-      to   <- targets.occupiedSquares
+      to   <- targets.squares
       move <- normalMove(from, to, Rook, isOccupied(to))
     yield move
 
   def genQueen(queens: Bitboard, mask: Bitboard): List[Move] =
     for
-      from <- queens.occupiedSquares
+      from <- queens.squares
       targets = from.queenAttacks(board.occupied) & mask
-      to   <- targets.occupiedSquares
+      to   <- targets.squares
       move <- normalMove(from, to, Queen, isOccupied(to))
     yield move
 
   def genUnsafeKing(king: Pos, mask: Bitboard): List[Move] =
     val targets = king.kingAttacks & mask
-    targets.occupiedSquares.flatMap(to => normalMove(king, to, King, isOccupied(to)))
+    targets.squares.flatMap(to => normalMove(king, to, King, isOccupied(to)))
 
   def genSafeKing(mask: Bitboard): List[Move] =
     ourKing.fold(Nil)(king =>
       val targets = king.kingAttacks & mask
       for
-        to <- targets.occupiedSquares
+        to <- targets.squares
         if board.attackers(to, !color).isEmpty
         move <- normalMove(king, to, King, isOccupied(to))
       yield move
@@ -257,7 +257,7 @@ case class Situation(board: Board, color: Color):
     else
       val rooks = history.unmovedRooks & Bitboard.rank(color.backRank) & board.rooks
       for
-        rook <- rooks.occupiedSquares
+        rook <- rooks.squares
         toKingFile = if rook < king then File.C else File.G
         toRookFile = if rook < king then File.D else File.F
         kingTo     = Pos(toKingFile, king.rank)
@@ -269,7 +269,7 @@ case class Situation(board: Board, color: Color):
           else Bitboard.between(king, rook)
         if (path & board.occupied & ~rook.bb).isEmpty
         kingPath = Bitboard.between(king, kingTo) | king.bb
-        if kingPath.occupiedSquares
+        if kingPath.squares
           .forall(variant.castleCheckSafeSquare(board, _, color, board.occupied ^ king.bb))
         if variant.castleCheckSafeSquare(
           board,

--- a/src/main/scala/UnmovedRooks.scala
+++ b/src/main/scala/UnmovedRooks.scala
@@ -10,8 +10,7 @@ object UnmovedRooks extends OpaqueBitboard[UnmovedRooks]:
   val corners: UnmovedRooks = CORNERS
   val none: UnmovedRooks    = empty
 
-  def apply(b: Bitboard): UnmovedRooks       = b.value
-  def apply(xs: Iterable[Pos]): UnmovedRooks = Bitboard(xs).value
+  def apply(b: Bitboard): UnmovedRooks = b.value
 
   // guess unmovedRooks from board
   // we assume rooks are on their initial position

--- a/src/main/scala/UnmovedRooks.scala
+++ b/src/main/scala/UnmovedRooks.scala
@@ -20,7 +20,7 @@ object UnmovedRooks extends OpaqueBitboard[UnmovedRooks]:
     UnmovedRooks(wr | br)
 
   extension (ur: UnmovedRooks)
-    def toList: List[Pos] = ur.occupiedSquares
+    def toList: List[Pos] = ur.squares
 
     def without(color: Color): UnmovedRooks =
       ur & Bitboard.rank(color.lastRank)

--- a/src/main/scala/bitboard/Bitboard.scala
+++ b/src/main/scala/bitboard/Bitboard.scala
@@ -32,8 +32,6 @@ object Bitboard extends OpaqueBitboard[Bitboard]:
   inline def file(inline f: File): Bitboard                  = FILES(f.value)
   inline def ray(inline from: Pos, inline to: Pos): Bitboard = RAYS(from.value)(to.value)
 
-  inline def apply(inline xs: Iterable[Pos]): Bitboard = xs.foldLeft(empty)((b, p) => b | p.bb)
-
   /** Slow attack set generation. Used only to bootstrap the attack tables.
     */
   private[bitboard] def slidingAttacks(square: Int, occupied: Bitboard, deltas: Array[Int]): Bitboard =

--- a/src/main/scala/bitboard/Board.scala
+++ b/src/main/scala/bitboard/Board.scala
@@ -59,7 +59,7 @@ case class Board(
     black.contains(s)
 
   def kings(color: Color): List[Pos] =
-    (kings & byColor(color)).occupiedSquares
+    (kings & byColor(color)).squares
 
   def kingOf(c: Color): Bitboard       = kings & byColor(c)
   def kingPosOf(c: Color): Option[Pos] = kingOf(c).singleSquare
@@ -96,7 +96,7 @@ case class Board(
           ourKing.bishopAttacks(Bitboard.empty) & (bishops ^ queens)
       )
       val bs = for
-        sniper <- snipers.occupiedSquares
+        sniper <- snipers.squares
         between = Bitboard.between(ourKing, sniper) & occupied
         if !between.moreThanOne
       yield between
@@ -177,7 +177,7 @@ case class Board(
     take(orig).map(_.putOrReplace(piece, dest))
 
   lazy val occupation: Color.Map[Set[Pos]] = Color.Map { c =>
-    color(c).occupiedSquares.toSet
+    color(c).squares.toSet
   }
 
   inline def isOccupied(inline p: Piece) =
@@ -185,7 +185,7 @@ case class Board(
 
   // TODO remove unsafe get
   lazy val pieceMap: Map[Pos, Piece] =
-    occupied.occupiedSquares.view.map(s => (s, pieceAt(s).get)).toMap
+    occupied.squares.view.map(s => (s, pieceAt(s).get)).toMap
 
   def piecesOf(c: Color): Map[Pos, Piece] =
     pieceMap.filter((_, p) => p.color == c)
@@ -193,7 +193,7 @@ case class Board(
   def pieces: List[Piece] = pieces(occupied)
 
   def pieces(occupied: Bitboard): List[Piece] =
-    occupied.occupiedSquares.flatMap(pieceAt)
+    occupied.squares.flatMap(pieceAt)
 
   def color(c: Color): Bitboard = c.fold(white, black)
 

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -8,6 +8,8 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
   protected val ALL: A     = -1L.bb
   protected val CORNERS: A = 0x8100000000000081L.bb
 
+  inline def apply(inline xs: Iterable[Pos]): A = xs.foldLeft(empty)((b, p) => b | p.bb)
+
   extension (l: Long)
     def bb: A                    = l.asInstanceOf[A]
     private def lsb: Option[Pos] = Pos.at(java.lang.Long.numberOfTrailingZeros(l))

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -42,7 +42,7 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
       if moreThanOne then None
       else first
 
-    def occupiedSquares: List[Pos] =
+    def squares: List[Pos] =
       fold(List.empty)((xs, pos) => pos :: xs)
 
     // total non empty position

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -32,7 +32,7 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
     def contains(pos: Pos): Boolean =
       (a.value & (1L << pos.value)) != 0L
 
-    def addPos(pos: Pos): A = a | pos.bb
+    def addSquare(pos: Pos): A = a | pos.bb
 
     def moreThanOne: Boolean =
       (a.value & (a.value - 1L)) != 0L

--- a/src/main/scala/format/FenReader.scala
+++ b/src/main/scala/format/FenReader.scala
@@ -6,7 +6,7 @@ import variant.{ Standard, Variant }
 import cats.kernel.Monoid
 import ornicar.scalalib.zeros.given_Zero_Option
 import bitboard.Bitboard
-import bitboard.Bitboard.{ bb, occupiedSquares }
+import bitboard.Bitboard.{ bb, squares }
 
 /** https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
   *
@@ -28,7 +28,7 @@ trait FenReader:
             .foldLeft(Castles.none -> UnmovedRooks.empty) { case ((c, r), ch) =>
               val color    = Color.fromWhite(ch.isUpper)
               val backRank = Bitboard.rank(color.backRank)
-              val rooks = (board.rooks & board(color) & backRank).occupiedSquares
+              val rooks = (board.rooks & board(color) & backRank).squares
                 .sortBy(_.file.value)
               {
                 for

--- a/src/main/scala/variant/Antichess.scala
+++ b/src/main/scala/variant/Antichess.scala
@@ -59,8 +59,8 @@ case object Antichess
     // Exit early if we are not in a situation with only knights
     situation.board.onlyKnights && {
 
-      val whiteKnights = situation.board.white.occupiedSquares
-      val blackKnights = situation.board.black.occupiedSquares
+      val whiteKnights = situation.board.white.squares
+      val blackKnights = situation.board.black.squares
 
       // We consider the case where a player has two knights
       if (whiteKnights.size != 1 || blackKnights.size != 1) false
@@ -79,14 +79,14 @@ case object Antichess
     // Exit early if we are not in a situation with only bishops and pawns
     if (board.bishops | board.pawns) != board.occupied then false
     else
-      val whiteBishops = (board.white & board.bishops).occupiedSquares
-      val blackBishops = (board.black & board.bishops).occupiedSquares
+      val whiteBishops = (board.white & board.bishops).squares
+      val blackBishops = (board.black & board.bishops).squares
       if whiteBishops.map(_.isLight).to(Set).size != 1 ||
         blackBishops.map(_.isLight).to(Set).size != 1
       then false
       else
-        val whitePawns = (board.white & board.pawns).occupiedSquares
-        val blackPawns = (board.black & board.pawns).occupiedSquares
+        val whitePawns = (board.white & board.pawns).squares
+        val blackPawns = (board.black & board.pawns).squares
         (for {
           whiteBishopLight <- whiteBishops.headOption map (_.isLight)
           blackBishopLight <- blackBishops.headOption map (_.isLight)

--- a/src/main/scala/variant/Crazyhouse.scala
+++ b/src/main/scala/variant/Crazyhouse.scala
@@ -93,7 +93,7 @@ case object Crazyhouse
     situation.ourKing.flatMap(king =>
       val checkers = situation.board.board.attackers(king, !situation.color)
       if checkers.moreThanOne then Some(Nil)
-      else checkers.first.map(checker => Bitboard.between(king, checker).occupiedSquares)
+      else checkers.first.map(Bitboard.between(king, _).squares)
     )
 
   // all legal moves and drops
@@ -129,7 +129,7 @@ case object Crazyhouse
           for
             role <- List(Knight, Bishop, Rook, Queen)
             if roles contains role
-            to <- targets.occupiedSquares
+            to <- targets.squares
             piece = Piece(situation.color, role)
             after = situation.board.place(piece, to).get // this is safe, we checked the target squares
             d2    = data.drop(piece).get                 // this is safe, we checked the pocket
@@ -137,7 +137,7 @@ case object Crazyhouse
         val dropWithPawn =
           if roles contains Pawn then
             for
-              to <- (targets & ~Bitboard.firstRank & ~Bitboard.lastRank).occupiedSquares
+              to <- (targets & ~Bitboard.firstRank & ~Bitboard.lastRank).squares
               piece = Piece(situation.color, Pawn)
               after = situation.board.place(piece, to).get // this is safe, we checked the target squares
               d2    = data.drop(piece).get                 // this is safe, we checked the pocket

--- a/src/main/scala/variant/Standard.scala
+++ b/src/main/scala/variant/Standard.scala
@@ -51,7 +51,7 @@ case object Standard
       // Checks by these sliding pieces can maybe be blocked.
       val sliders = checkers & (board.sliders)
       val attacked =
-        sliders.occupiedSquares.foldLeft(Bitboard.empty)((a, s) => a | (s.bb ^ Bitboard.ray(king, s)))
+        sliders.squares.foldLeft(Bitboard.empty)((a, s) => a | (s.bb ^ Bitboard.ray(king, s)))
       val safeKings = genSafeKing(~us & ~attacked)
       val blockers =
         checkers.singleSquare.map(c => genNonKing(Bitboard.between(king, c) | checkers)).getOrElse(Nil)

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -227,7 +227,7 @@ class AtomicVariantTest extends ChessTest:
         game.board(Pos.E6) must beNone // The pawn that captures during en-passant should explode
         // Every piece surrounding the en-passant destination square that is not a pawn should be empty
         import bitboard.Bitboard.*
-        Pos.E6.kingAttacks.occupiedSquares
+        Pos.E6.kingAttacks.squares
           .forall(pos => game.board(pos).isEmpty || pos == Pos.E7 || pos == Pos.D7) must beTrue
       }
     }

--- a/src/test/scala/UnmovedRooksTest.scala
+++ b/src/test/scala/UnmovedRooksTest.scala
@@ -38,7 +38,7 @@ class UnmovedRooksTest extends ChessTest:
 
   chess960Boards.mapWithIndex { (board, n) =>
     s"unmovedRooks at position number: $n" in {
-      board.rooks.occupiedSquares.traverse { pos =>
+      board.rooks.squares.traverse { pos =>
         board.history.unmovedRooks.side(pos).flatten
       } must beSome { (sides: List[Side]) =>
         sides.filter(_ == QueenSide).size must_== 2

--- a/src/test/scala/bitboard/OpaqueBitboardTest.scala
+++ b/src/test/scala/bitboard/OpaqueBitboardTest.scala
@@ -10,9 +10,9 @@ import Bitboard.*
 
 class OpaqueBitboardTest extends ScalaCheckSuite:
 
-  test("the result of addPos should contain the added pos") {
+  test("the result of addSquare should contain the added pos") {
     forAll { (bb: Bitboard, pos: Pos) =>
-      assertEquals((bb.addPos(pos).contains(pos)), true)
+      assertEquals((bb.addSquare(pos).contains(pos)), true)
     }
   }
 
@@ -78,10 +78,10 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
     }
   }
 
-  test("apply set of pos should be the same as using addPos") {
+  test("apply set of pos should be the same as using addSquare") {
     forAll { (xs: Set[Pos]) =>
       val bb  = Bitboard(xs)
-      val bb2 = xs.foldLeft(Bitboard.empty)(_ addPos _)
+      val bb2 = xs.foldLeft(Bitboard.empty)(_ addSquare _)
       assertEquals(bb, bb2)
     }
   }
@@ -100,7 +100,7 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
 
   test("intersects should be true when the two bitboards have at least one common square") {
     forAll { (b1: Bitboard, b2: Bitboard, p: Pos) =>
-      b1.addPos(p).intersects(b2.addPos(p))
+      b1.addSquare(p).intersects(b2.addSquare(p))
     }
   }
 
@@ -115,7 +115,7 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
 
   test("isDisjoint should be false when the two bitboards have at least common square") {
     forAll { (b1: Bitboard, b2: Bitboard, p: Pos) =>
-      !b1.addPos(p).isDisjoint(b2.addPos(p))
+      !b1.addSquare(p).isDisjoint(b2.addSquare(p))
     }
   }
 

--- a/src/test/scala/bitboard/OpaqueBitboardTest.scala
+++ b/src/test/scala/bitboard/OpaqueBitboardTest.scala
@@ -86,6 +86,13 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
     }
   }
 
+  test("apply(Set[Pos]).squares.toSet == Set[Pos]") {
+    forAll { (xs: Set[Pos]) =>
+      val result = Bitboard(xs).squares.toSet
+      assertEquals(result, xs)
+    }
+  }
+
   test("nonEmpty bitboard should have at least one square") {
     forAll { (bb: Bitboard) =>
       assertEquals(bb.nonEmpty, bb.first.isDefined)

--- a/src/test/scala/bitboard/OpaqueBitboardTest.scala
+++ b/src/test/scala/bitboard/OpaqueBitboardTest.scala
@@ -22,9 +22,9 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
     }
   }
 
-  test("count has the same value as occupiedSquares.size") {
+  test("count has the same value as squares.size") {
     forAll { (bb: Bitboard) =>
-      assertEquals(bb.count, bb.occupiedSquares.size)
+      assertEquals(bb.count, bb.squares.size)
     }
   }
 
@@ -92,9 +92,9 @@ class OpaqueBitboardTest extends ScalaCheckSuite:
     }
   }
 
-  test("first should be the minimum of occupiedSquares") {
+  test("first should be the minimum of squares") {
     forAll { (bb: Bitboard) =>
-      assertEquals(bb.first, bb.occupiedSquares.minByOption(_.value))
+      assertEquals(bb.first, bb.squares.minByOption(_.value))
     }
   }
 


### PR DESCRIPTION
Some minor simplify and cleanup `OpaqueBitboard`, to make it's API more consistent
- Move apply(List[Post]) to OpaqueBitboard
- Refactor `OpaqueBitboard`: `occupiedSquares` => `squares`
- Refactor `OpaqueBitboard`: `addPos` => `addSquare`

I believe we should Refactor `Pos` to `Square` in future to make scalachess more consistent with our other chess libraries. But it can be in another PR when we decide to break things to have better API.