### PR TITLE
Improve Dumper

### DIFF
--- a/src/main/scala/Board.scala
+++ b/src/main/scala/Board.scala
@@ -17,6 +17,8 @@ case class Board(
     bishops,
     black,
     byColor,
+    byPiece,
+    byRole,
     isCheck,
     isOccupied,
     kingOf,

--- a/src/main/scala/Piece.scala
+++ b/src/main/scala/Piece.scala
@@ -16,13 +16,12 @@ case class Piece(color: Color, role: Role):
   // attackable positions assuming empty board
   import bitboard.Bitboard
   import bitboard.Bitboard.*
-  def eyes(from: Pos, to: Pos): Boolean =
-    val occupied: Bitboard = to.bb
+  def eyes(from: Pos, to: Pos, mask: Bitboard): Boolean =
     role match
       case King   => from.kingAttacks.contains(to)
-      case Queen  => from.queenAttacks(occupied).nonEmpty
-      case Rook   => from.rookAttacks(occupied).nonEmpty
-      case Bishop => from.bishopAttacks(occupied).nonEmpty
+      case Queen  => from.queenAttacks(mask).contains(to)
+      case Rook   => from.rookAttacks(mask).contains(to)
+      case Bishop => from.bishopAttacks(mask).contains(to)
       case Knight => from.knightAttacks.contains(to)
       case Pawn   => from.pawnAttacks(color).contains(to)
 

--- a/src/main/scala/Piece.scala
+++ b/src/main/scala/Piece.scala
@@ -1,5 +1,8 @@
 package chess
 
+import bitboard.Bitboard
+import bitboard.Bitboard.*
+
 case class Piece(color: Color, role: Role):
 
   def is(c: Color)   = c == color
@@ -13,9 +16,7 @@ case class Piece(color: Color, role: Role):
 
   def forsyth: Char = if color.white then role.forsythUpper else role.forsyth
 
-  // attackable positions assuming empty board
-  import bitboard.Bitboard
-  import bitboard.Bitboard.*
+  // the piece at from can attack the target to when mask are all the occupied squares
   def eyes(from: Pos, to: Pos, mask: Bitboard): Boolean =
     role match
       case King   => from.kingAttacks.contains(to)

--- a/src/main/scala/bitboard/Board.scala
+++ b/src/main/scala/bitboard/Board.scala
@@ -32,6 +32,9 @@ case class Board(
       case Queen  => queens
       case King   => kings
 
+  def byPiece(piece: Piece): Bitboard =
+    byColor(piece.color) & byRole(piece.role)
+
   def roleAt(s: Pos): Option[Role] =
     if pawns.contains(s) then Some(Pawn)
     else if knights.contains(s) then Some(Knight)

--- a/src/main/scala/format/pgn/Dumper.scala
+++ b/src/main/scala/format/pgn/Dumper.scala
@@ -27,7 +27,7 @@ object Dumper:
         // We know Role ≠ Pawn, so it is fine to always pass None as promotion target
         val candidates = (situation.board.byPiece(piece) ^ orig.bb).occupiedSquares
           .filter(square =>
-            piece.eyes(square, dest) && {
+            piece.eyes(square, dest, situation.board.occupied) && {
               situation.move(square, dest, None).isValid
             }
           )

--- a/src/main/scala/format/pgn/Dumper.scala
+++ b/src/main/scala/format/pgn/Dumper.scala
@@ -24,12 +24,13 @@ object Dumper:
         //       - file
         //       - rank
         //       - both (only happens w/ at least 3 pieces of the same role)
-        val candidates = situation.board.byPiece(piece).occupiedSquares collect {
-          case square if square != orig && piece.eyes(square, dest) => square
-        } filter { square =>
-          // We know Role ≠ Pawn, so it is fine to always pass None as promotion target
-          situation.move(square, dest, None).isValid
-        }
+        // We know Role ≠ Pawn, so it is fine to always pass None as promotion target
+        val candidates = (situation.board.byPiece(piece) ^ orig.bb).occupiedSquares
+          .filter(square =>
+            piece.eyes(square, dest) && {
+              situation.move(square, dest, None).isValid
+            }
+          )
 
         val disambiguation: String =
           if (candidates.isEmpty)

--- a/src/main/scala/format/pgn/Dumper.scala
+++ b/src/main/scala/format/pgn/Dumper.scala
@@ -5,6 +5,7 @@ object Dumper:
 
   def apply(situation: Situation, data: chess.Move, next: Situation): SanStr =
     import data.*
+    import bitboard.Bitboard.*
 
     val base = (promotion, piece.role) match
       case _ if castles =>
@@ -23,11 +24,11 @@ object Dumper:
         //       - file
         //       - rank
         //       - both (only happens w/ at least 3 pieces of the same role)
-        val candidates = situation.board.pieces collect {
-          case (cpos, cpiece) if cpiece == piece && cpos != orig && cpiece.eyes(cpos, dest) => cpos
-        } filter { cpos =>
+        val candidates = situation.board.byPiece(piece).occupiedSquares collect {
+          case square if square != orig && piece.eyes(square, dest) => square
+        } filter { square =>
           // We know Role ≠ Pawn, so it is fine to always pass None as promotion target
-          situation.move(cpos, dest, None).isValid
+          situation.move(square, dest, None).isValid
         }
 
         val disambiguation: String =
@@ -48,10 +49,10 @@ object Dumper:
     SanStr(s"${data.toUci.uci}${checkOrWinnerSymbol(next)}")
 
   def apply(data: chess.Move): SanStr =
-    apply(data.situationBefore, data, data.finalizeAfter situationOf !data.color)
+    apply(data.situationBefore, data, data.situationAfter)
 
   def apply(data: chess.Drop): SanStr =
-    apply(data, data.finalizeAfter situationOf !data.color)
+    apply(data, data.situationAfter)
 
   private def checkOrWinnerSymbol(next: Situation): String =
     if next.winner.isDefined then "#"

--- a/src/main/scala/format/pgn/parsingModel.scala
+++ b/src/main/scala/format/pgn/parsingModel.scala
@@ -50,7 +50,7 @@ case class Std(
   def withMetas(m: Metas) = copy(metas = m)
 
   def move(situation: Situation): Validated[ErrorStr, chess.Move] =
-    val pieces = situation.board.board.byRole(role) & situation.us
+    val pieces = situation.board.byPiece(situation.color - role)
     pieces.first { pos =>
       if compare(file, pos.file.index + 1) &&
         compare(rank, pos.rank.index + 1)

--- a/src/test/scala/bitboard/BitboardTest.scala
+++ b/src/test/scala/bitboard/BitboardTest.scala
@@ -76,11 +76,6 @@ class BitboardTest extends ScalaCheckSuite:
     }
   }
 
-  test("special bishop attacks") {
-    val result = F8.bishopAttacks(G4.bb).nonEmpty
-    assertEquals(result, false)
-  }
-
   property("rook attacks") {
     Prop.forAll { (occupied: Bitboard, s: Pos) =>
       s.rookAttacks(occupied) == CBB.rookAttacks(s, occupied).bb

--- a/src/test/scala/bitboard/BitboardTest.scala
+++ b/src/test/scala/bitboard/BitboardTest.scala
@@ -4,6 +4,7 @@ package bitboard
 import munit.ScalaCheckSuite
 import org.lichess.compression.game.Bitboard as CBB
 import org.scalacheck.Prop
+import Pos.*
 
 import Arbitraries.given
 
@@ -69,10 +70,15 @@ class BitboardTest extends ScalaCheckSuite:
     }
   }
 
-  property("bitshop attacks") {
+  property("bishop attacks") {
     Prop.forAll { (occupied: Bitboard, s: Pos) =>
       s.bishopAttacks(occupied) == CBB.bishopAttacks(s, occupied).bb
     }
+  }
+
+  test("special bishop attacks") {
+    val result = F8.bishopAttacks(G4.bb).nonEmpty
+    assertEquals(result, false)
   }
 
   property("rook attacks") {


### PR DESCRIPTION
Improve Dumper implementation by only traverse the moving pieces instead of the all pieces. This also fix the broken `Piece.eyes` function. So this should improve our `ReplayBench` quite a bit. Will Run benchmark and post here when I have time.