### PR TITLE
Reduce number of nodeLimits to reduce CI time

### DIFF
--- a/src/test/scala/perft/FullPerftTest.scala
+++ b/src/test/scala/perft/FullPerftTest.scala
@@ -14,7 +14,7 @@ object FullPerftTest extends SimpleIOSuite:
     def empty                           = true
     def combine(x: Boolean, y: Boolean) = x && y
 
-  val nodeLimits = 10_000_000L
+  val nodeLimits = 1_000_000L
 
   test("random.perft"):
     perfts(Perft.randomPerfts, Chess960, 10_000L)


### PR DESCRIPTION
Now the CI usually takes 30-40 minutes to finish - most of the time is for the `perft` tests.
It is okay, but a bit annoying to wait, especially when you don't touch move generator part.

This PR is to reduce the number of `nodeLimits` from 10M to 1M. Which in turn will reduce significant CI time.

I also have a project which exist for the pure purpose of testing scalachess here: https://github.com/lenguyenthanh/scalachess-tests, I bump the scalachess version occasionally to make sure `scalachess` behaves correctly.
 