### PR TITLE
Improve OpaqueBitboard

### DIFF
--- a/src/main/scala/Hash.scala
+++ b/src/main/scala/Hash.scala
@@ -97,7 +97,7 @@ object Hash extends OpaqueInt[Hash]:
 
     // Hash in special crazyhouse data.
     board.crazyData.fold(hchecks) { data =>
-      val hcrazypromotions: Long = data.promoted.squares
+      val hcrazypromotions: Long = data.promoted
         .map { p => table.crazyPromotionMasks(p.hashCode) }
         .fold(hchecks)(_ ^ _)
       Color.all

--- a/src/main/scala/InsufficientMatingMaterial.scala
+++ b/src/main/scala/InsufficientMatingMaterial.scala
@@ -10,7 +10,7 @@ object InsufficientMatingMaterial:
   // verify if there are at least two bishops of opposite color
   // no matter which sides they are on
   def bishopsOnOppositeColors(board: Board) =
-    board.bishops.squares.map(_.isLight).distinct.size == 2
+    board.bishops.map(_.isLight).distinct.size == 2
 
   /*
    * Returns true if a pawn cannot progress forward because it is blocked by a pawn

--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -170,8 +170,7 @@ case class Situation(board: Board, color: Color):
 
     val s1: List[Move] = for
       from <- capturers
-      targets = from.pawnAttacks(color) & them & mask
-      to   <- targets
+      to   <- from.pawnAttacks(color) & them & mask
       move <- genPawnMoves(from, to, true)
     yield move
 
@@ -204,44 +203,38 @@ case class Situation(board: Board, color: Color):
   def genKnight(knights: Bitboard, mask: Bitboard): List[Move] =
     for
       from <- knights
-      targets = Bitboard.knightAttacks(from) & mask
-      to   <- targets
+      to   <- Bitboard.knightAttacks(from) & mask
       move <- normalMove(from, to, Knight, isOccupied(to))
     yield move
 
   def genBishop(bishops: Bitboard, mask: Bitboard): List[Move] =
     for
       from <- bishops
-      targets = from.bishopAttacks(board.occupied) & mask
-      to   <- targets
+      to   <- from.bishopAttacks(board.occupied) & mask
       move <- normalMove(from, to, Bishop, isOccupied(to))
     yield move
 
   def genRook(rooks: Bitboard, mask: Bitboard): List[Move] =
     for
       from <- rooks
-      targets = from.rookAttacks(board.occupied) & mask
-      to   <- targets
+      to   <- from.rookAttacks(board.occupied) & mask
       move <- normalMove(from, to, Rook, isOccupied(to))
     yield move
 
   def genQueen(queens: Bitboard, mask: Bitboard): List[Move] =
     for
       from <- queens
-      targets = from.queenAttacks(board.occupied) & mask
-      to   <- targets
+      to   <- from.queenAttacks(board.occupied) & mask
       move <- normalMove(from, to, Queen, isOccupied(to))
     yield move
 
   def genUnsafeKing(king: Square, mask: Bitboard): List[Move] =
-    val targets = king.kingAttacks & mask
-    targets.flatMap(to => normalMove(king, to, King, isOccupied(to)))
+    (king.kingAttacks & mask).flatMap(to => normalMove(king, to, King, isOccupied(to)))
 
   def genSafeKing(mask: Bitboard): List[Move] =
     ourKing.fold(Nil)(king =>
-      val targets = king.kingAttacks & mask
       for
-        to <- targets
+        to <- king.kingAttacks & mask
         if board.attackers(to, !color).isEmpty
         move <- normalMove(king, to, King, isOccupied(to))
       yield move

--- a/src/main/scala/Situation.scala
+++ b/src/main/scala/Situation.scala
@@ -169,9 +169,9 @@ case class Situation(board: Board, color: Color):
     val capturers = pawns
 
     val s1: List[Move] = for
-      from <- capturers.squares
+      from <- capturers
       targets = from.pawnAttacks(color) & them & mask
-      to   <- targets.squares
+      to   <- targets
       move <- genPawnMoves(from, to, true)
     yield move
 
@@ -188,13 +188,13 @@ case class Situation(board: Board, color: Color):
          else Bitboard.rank(color.fourthRank))
 
     val s2: List[Move] = for
-      to   <- (singleMoves & mask).squares
+      to   <- singleMoves & mask
       from <- Square.at(to.value + (if isWhiteTurn then -8 else 8)).toList
       move <- genPawnMoves(from, to, false)
     yield move
 
     val s3: List[Move] = for
-      to   <- (doubleMoves & mask).squares
+      to   <- doubleMoves & mask
       from <- Square.at(to.value + (if isWhiteTurn then -16 else 16))
       move <- normalMove(from, to, Pawn, false)
     yield move
@@ -203,45 +203,45 @@ case class Situation(board: Board, color: Color):
 
   def genKnight(knights: Bitboard, mask: Bitboard): List[Move] =
     for
-      from <- knights.squares
+      from <- knights
       targets = Bitboard.knightAttacks(from) & mask
-      to   <- targets.squares
+      to   <- targets
       move <- normalMove(from, to, Knight, isOccupied(to))
     yield move
 
   def genBishop(bishops: Bitboard, mask: Bitboard): List[Move] =
     for
-      from <- bishops.squares
+      from <- bishops
       targets = from.bishopAttacks(board.occupied) & mask
-      to   <- targets.squares
+      to   <- targets
       move <- normalMove(from, to, Bishop, isOccupied(to))
     yield move
 
   def genRook(rooks: Bitboard, mask: Bitboard): List[Move] =
     for
-      from <- rooks.squares
+      from <- rooks
       targets = from.rookAttacks(board.occupied) & mask
-      to   <- targets.squares
+      to   <- targets
       move <- normalMove(from, to, Rook, isOccupied(to))
     yield move
 
   def genQueen(queens: Bitboard, mask: Bitboard): List[Move] =
     for
-      from <- queens.squares
+      from <- queens
       targets = from.queenAttacks(board.occupied) & mask
-      to   <- targets.squares
+      to   <- targets
       move <- normalMove(from, to, Queen, isOccupied(to))
     yield move
 
   def genUnsafeKing(king: Square, mask: Bitboard): List[Move] =
     val targets = king.kingAttacks & mask
-    targets.squares.flatMap(to => normalMove(king, to, King, isOccupied(to)))
+    targets.flatMap(to => normalMove(king, to, King, isOccupied(to)))
 
   def genSafeKing(mask: Bitboard): List[Move] =
     ourKing.fold(Nil)(king =>
       val targets = king.kingAttacks & mask
       for
-        to <- targets.squares
+        to <- targets
         if board.attackers(to, !color).isEmpty
         move <- normalMove(king, to, King, isOccupied(to))
       yield move
@@ -253,7 +253,7 @@ case class Situation(board: Board, color: Color):
     else
       val rooks = history.unmovedRooks & Bitboard.rank(color.backRank) & board.rooks
       for
-        rook <- rooks.squares
+        rook <- rooks
         toKingFile = if rook < king then File.C else File.G
         toRookFile = if rook < king then File.D else File.F
         kingTo     = Square(toKingFile, king.rank)
@@ -265,8 +265,7 @@ case class Situation(board: Board, color: Color):
           else Bitboard.between(king, rook)
         if (path & board.occupied & ~rook.bb).isEmpty
         kingPath = Bitboard.between(king, kingTo) | king.bb
-        if kingPath.squares
-          .forall(variant.castleCheckSafeSquare(board, _, color, board.occupied ^ king.bb))
+        if kingPath.forall(variant.castleCheckSafeSquare(board, _, color, board.occupied ^ king.bb))
         if variant.castleCheckSafeSquare(
           board,
           kingTo,

--- a/src/main/scala/bitboard/Board.scala
+++ b/src/main/scala/bitboard/Board.scala
@@ -90,11 +90,10 @@ case class Board(
       ourKing.rookAttacks(Bitboard.empty) & (rooks ^ queens) |
         ourKing.bishopAttacks(Bitboard.empty) & (bishops ^ queens)
     )
-    snipers.squares.foldLeft(Bitboard.empty) { case (blockers, sniper) =>
+    snipers.fold(Bitboard.empty): (blockers, sniper) =>
       val between = Bitboard.between(ourKing, sniper) & occupied
       if between.moreThanOne then blockers
       else blockers | between
-    }
 
   def discard(s: Square): Board =
     discard(s.bb)
@@ -164,7 +163,7 @@ case class Board(
   def pieces: List[Piece] = pieces(occupied)
 
   def pieces(occupied: Bitboard): List[Piece] =
-    occupied.squares.flatMap(pieceAt)
+    occupied.flatMap(pieceAt)
 
   def color(c: Color): Bitboard = c.fold(white, black)
 

--- a/src/main/scala/bitboard/OpaqueBitboard.scala
+++ b/src/main/scala/bitboard/OpaqueBitboard.scala
@@ -44,7 +44,13 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
       else first
 
     def squares: List[Square] =
-      fold(List.empty)((xs, square) => square :: xs)
+      var b       = a.value
+      val builder = List.newBuilder[Square]
+      while b != 0L
+      do
+        builder += b.lsb.get
+        b &= (b - 1L)
+      builder.result
 
     // total non empty position
     def count: Int = java.lang.Long.bitCount(a)
@@ -85,12 +91,58 @@ trait OpaqueBitboard[A](using A =:= Long) extends TotalWrapper[A, Long]:
         b &= (b - 1L)
       result
 
+    def filter(f: Square => Boolean): List[Square] =
+      val builder = List.newBuilder[Square]
+      var b       = a.value
+      while b != 0L
+      do
+        if f(b.lsb.get) then builder += b.lsb.get
+        b &= (b - 1L)
+      builder.result
+
+    def withFilter(f: Square => Boolean): List[Square] =
+      filter(f)
+
+    def foreach[U](f: Square => U): Unit =
+      var b = a.value
+      while b != 0L
+      do
+        f(b.lsb.get)
+        b &= (b - 1L)
+
+    def forall[B](f: Square => Boolean): Boolean =
+      var b      = a.value
+      var result = true
+      while b != 0L && result
+      do
+        result = f(b.lsb.get)
+        b &= (b - 1L)
+      result
+
+    def exists[B](f: Square => Boolean): Boolean =
+      var b      = a.value
+      var result = false
+      while b != 0L && !result
+      do
+        result = f(b.lsb.get)
+        b &= (b - 1L)
+      result
+
     def flatMap[B](f: Square => IterableOnce[B]): List[B] =
       var b       = a.value
       val builder = List.newBuilder[B]
       while b != 0L
       do
         builder ++= f(b.lsb.get)
+        b &= (b - 1L)
+      builder.result
+
+    def map[B](f: Square => B): List[B] =
+      var b       = a.value
+      val builder = List.newBuilder[B]
+      while b != 0L
+      do
+        builder += f(b.lsb.get)
         b &= (b - 1L)
       builder.result
 

--- a/src/main/scala/format/pgn/Dumper.scala
+++ b/src/main/scala/format/pgn/Dumper.scala
@@ -25,7 +25,7 @@ object Dumper:
         //       - rank
         //       - both (only happens w/ at least 3 pieces of the same role)
         // We know Role ≠ Pawn, so it is fine to always pass None as promotion target
-        val candidates = (situation.board.byPiece(piece) ^ orig.bb).squares
+        val candidates = (situation.board.byPiece(piece) ^ orig.bb)
           .filter(square =>
             piece.eyes(square, dest, situation.board.occupied) && {
               situation.move(square, dest, None).isValid

--- a/src/main/scala/format/pgn/Glyph.scala
+++ b/src/main/scala/format/pgn/Glyph.scala
@@ -13,7 +13,7 @@ case class Glyphs(
 
   def isEmpty = this == Glyphs.empty
 
-  def nonEmpty: Option[Glyphs] = if isEmpty then None else Option(this)
+  def nonEmpty: Option[Glyphs] = Option.when(!isEmpty)(this)
 
   def toggle(glyph: Glyph) =
     glyph match

--- a/src/main/scala/variant/Crazyhouse.scala
+++ b/src/main/scala/variant/Crazyhouse.scala
@@ -138,7 +138,7 @@ case object Crazyhouse
         val dropWithPawn =
           if pocket contains Pawn then
             for
-              to <- (targets & ~Bitboard.firstRank & ~Bitboard.lastRank)
+              to <- targets & ~Bitboard.firstRank & ~Bitboard.lastRank
               piece = Piece(situation.color, Pawn)
               after = situation.board.place(piece, to).get // this is safe, we checked the target squares
               d2    = data.drop(piece).get                 // this is safe, we checked the pocket

--- a/src/main/scala/variant/Crazyhouse.scala
+++ b/src/main/scala/variant/Crazyhouse.scala
@@ -130,7 +130,7 @@ case object Crazyhouse
           for
             role <- List(Knight, Bishop, Rook, Queen)
             if pocket contains role
-            to <- targets.squares
+            to <- targets
             piece = Piece(situation.color, role)
             after = situation.board.place(piece, to).get // this is safe, we checked the target squares
             d2    = data.drop(piece).get                 // this is safe, we checked the pocket
@@ -138,7 +138,7 @@ case object Crazyhouse
         val dropWithPawn =
           if pocket contains Pawn then
             for
-              to <- (targets & ~Bitboard.firstRank & ~Bitboard.lastRank).squares
+              to <- (targets & ~Bitboard.firstRank & ~Bitboard.lastRank)
               piece = Piece(situation.color, Pawn)
               after = situation.board.place(piece, to).get // this is safe, we checked the target squares
               d2    = data.drop(piece).get                 // this is safe, we checked the pocket
@@ -228,7 +228,7 @@ case object Crazyhouse
         case King   => None
 
     def take(role: Role): Option[Pocket] =
-      update(role, (x => if x > 0 then Some(x - 1) else None))
+      update(role, (x => Option.when(x > 0)(x - 1)))
 
     def store(role: Role): Pocket = update(role, _ + 1)
 
@@ -251,6 +251,4 @@ case object Crazyhouse
   object Pocket:
     val empty = Pocket(0, 0, 0, 0, 0)
     def apply(roles: List[Role]): Pocket =
-      roles.foldLeft(empty) { (p, r) =>
-        p store r
-      }
+      roles.foldLeft(empty)(_ store _)

--- a/src/main/scala/variant/Standard.scala
+++ b/src/main/scala/variant/Standard.scala
@@ -52,7 +52,7 @@ case object Standard
       // Checks by these sliding pieces can maybe be blocked.
       val sliders = checkers & (board.sliders)
       val attacked =
-        sliders.squares.foldLeft(Bitboard.empty)((a, s) => a | (s.bb ^ Bitboard.ray(king, s)))
+        sliders.fold(Bitboard.empty)((a, s) => a | (s.bb ^ Bitboard.ray(king, s)))
       val safeKings = genSafeKing(~us & ~attacked)
       val blockers =
         checkers.singleSquare.map(c => genNonKing(Bitboard.between(king, c) | checkers)).getOrElse(Nil)

--- a/src/test/scala/AtomicVariantTest.scala
+++ b/src/test/scala/AtomicVariantTest.scala
@@ -212,7 +212,7 @@ class AtomicVariantTest extends ChessTest:
         game.board(Square.E6) must beNone // The pawn that captures during en-passant should explode
         // Every piece surrounding the en-passant destination square that is not a pawn should be empty
         import bitboard.Bitboard.*
-        Square.E6.kingAttacks.squares
+        Square.E6.kingAttacks
           .forall(square =>
             game.board(square).isEmpty || square == Square.E7 || square == Square.D7
           ) must beTrue

--- a/src/test/scala/bitboard/Arbitraries.scala
+++ b/src/test/scala/bitboard/Arbitraries.scala
@@ -1,7 +1,7 @@
 package chess
 package bitboard
 
-import org.scalacheck.{ Arbitrary, Gen }
+import org.scalacheck.{ Arbitrary, Cogen, Gen }
 
 object Arbitraries:
 
@@ -10,3 +10,5 @@ object Arbitraries:
   given Arbitrary[Square] = Arbitrary(Gen.oneOf(Square.all))
 
   given Arbitrary[Bitboard] = Arbitrary(Gen.long.map(Bitboard(_)))
+
+  given Cogen[Square] = Cogen(_.value.toLong)

--- a/src/test/scala/bitboard/BitboardTest.scala
+++ b/src/test/scala/bitboard/BitboardTest.scala
@@ -81,39 +81,3 @@ class BitboardTest extends ScalaCheckSuite:
     Prop.forAll: (s: Square) =>
       s.pawnAttacks(Color.White) == CBB.pawnAttacks(true, s).bb
       s.pawnAttacks(Color.Black) == CBB.pawnAttacks(false, s).bb
-
-  property("forall"):
-    Prop.forAll: (b: Bitboard, f: Square => Boolean) =>
-      b.forall(f) == b.squares.forall(f)
-
-  property("exists"):
-    Prop.forAll: (b: Bitboard, f: Square => Boolean) =>
-      b.exists(f) == b.squares.exists(f)
-
-  property("map"):
-    Prop.forAll: (b: Bitboard, f: Square => Int) =>
-      b.map(f) == b.squares.map(f)
-
-  property("flatMap"):
-    Prop.forAll: (b: Bitboard, f: Square => Option[Int]) =>
-      b.flatMap(f) == b.squares.flatMap(f)
-
-  property("filter"):
-    Prop.forAll: (b: Bitboard, f: Square => Boolean) =>
-      b.filter(f) == b.squares.filter(f)
-
-  property("first"):
-    Prop.forAll: (b: Bitboard, f: Square => Option[Int]) =>
-      b.first(f) == b.squares.map(f).find(_.isDefined).flatten
-
-  property("foreach"):
-    Prop.forAll: (b: Bitboard, f: Square => Int) =>
-      var s1 = 0L
-      var s2 = 0L
-      b.foreach(x => s1 += f(x).toLong)
-      b.squares.foreach(x => s2 += f(x).toLong)
-      s1 == s2
-
-  test("count"):
-    Prop.forAll: (b: Bitboard) =>
-      b.count == b.squares.size

--- a/src/test/scala/bitboard/BitboardTest.scala
+++ b/src/test/scala/bitboard/BitboardTest.scala
@@ -47,14 +47,13 @@ class BitboardTest extends ScalaCheckSuite:
     yield assertEquals(result, expected.bb)
 
   property("slidingAttack check"):
-    Prop.forAll { (occupied: Bitboard, s: Square) =>
+    Prop.forAll: (occupied: Bitboard, s: Square) =>
       val result = for
         deltas <- allDeltas
         result   = Bitboard.slidingAttacks(s, occupied, deltas)
         expected = CBB.slidingAttacks(s, occupied, deltas)
       yield result == expected.bb
       result.forall(identity)
-    }
 
   test("init function"):
     assertEquals(Bitboard.KNIGHT_ATTACKS.toSeq, CBB.KNIGHT_ATTACKS.toSeq)
@@ -67,28 +66,54 @@ class BitboardTest extends ScalaCheckSuite:
     }
 
   property("bishop attacks"):
-    Prop.forAll { (occupied: Bitboard, s: Square) =>
+    Prop.forAll: (occupied: Bitboard, s: Square) =>
       s.bishopAttacks(occupied) == CBB.bishopAttacks(s, occupied).bb
-    }
 
   property("rook attacks"):
-    Prop.forAll { (occupied: Bitboard, s: Square) =>
+    Prop.forAll: (occupied: Bitboard, s: Square) =>
       s.rookAttacks(occupied) == CBB.rookAttacks(s, occupied).bb
-    }
 
   property("queen attacks"):
-    Prop.forAll { (occupied: Bitboard, s: Square) =>
+    Prop.forAll: (occupied: Bitboard, s: Square) =>
       s.queenAttacks(occupied) == CBB.queenAttacks(s, occupied).bb
-    }
 
   property("pawn attacks"):
-    Prop.forAll { (s: Square) =>
+    Prop.forAll: (s: Square) =>
       s.pawnAttacks(Color.White) == CBB.pawnAttacks(true, s).bb
       s.pawnAttacks(Color.Black) == CBB.pawnAttacks(false, s).bb
-    }
+
+  property("forall"):
+    Prop.forAll: (b: Bitboard, f: Square => Boolean) =>
+      b.forall(f) == b.squares.forall(f)
+
+  property("exists"):
+    Prop.forAll: (b: Bitboard, f: Square => Boolean) =>
+      b.exists(f) == b.squares.exists(f)
+
+  property("map"):
+    Prop.forAll: (b: Bitboard, f: Square => Int) =>
+      b.map(f) == b.squares.map(f)
+
+  property("flatMap"):
+    Prop.forAll: (b: Bitboard, f: Square => Option[Int]) =>
+      b.flatMap(f) == b.squares.flatMap(f)
+
+  property("filter"):
+    Prop.forAll: (b: Bitboard, f: Square => Boolean) =>
+      b.filter(f) == b.squares.filter(f)
+
+  property("first"):
+    Prop.forAll: (b: Bitboard, f: Square => Option[Int]) =>
+      b.first(f) == b.squares.map(f).find(_.isDefined).flatten
+
+  property("foreach"):
+    Prop.forAll: (b: Bitboard, f: Square => Int) =>
+      var s1 = 0L
+      var s2 = 0L
+      b.foreach(x => s1 += f(x).toLong)
+      b.squares.foreach(x => s2 += f(x).toLong)
+      s1 == s2
 
   test("count"):
-    assertEquals(1024L.bb.count, 1)
-    assertEquals(4264L.bb.count, 4)
-    assertEquals((1L.bb & Square.A1.bb).nonEmpty, true)
-    assertEquals(Castles(1L).can(White), true)
+    Prop.forAll: (b: Bitboard) =>
+      b.count == b.squares.size

--- a/src/test/scala/bitboard/OpaqueBitboardTest.scala
+++ b/src/test/scala/bitboard/OpaqueBitboardTest.scala
@@ -2,8 +2,7 @@ package chess
 package bitboard
 
 import munit.ScalaCheckSuite
-import org.scalacheck.Prop.forAll
-import org.scalacheck.Prop.propBoolean
+import org.scalacheck.Prop.{ forAll, propBoolean }
 
 import Arbitraries.given
 import Bitboard.*
@@ -11,109 +10,122 @@ import Bitboard.*
 class OpaqueBitboardTest extends ScalaCheckSuite:
 
   test("the result of addSquare should contain the added square"):
-    forAll { (bb: Bitboard, square: Square) =>
+    forAll: (bb: Bitboard, square: Square) =>
       assertEquals((bb.addSquare(square).contains(square)), true)
-    }
 
   test("Square.bb.singleSquare == Some(square)"):
-    forAll { (square: Square) =>
+    forAll: (square: Square) =>
       assertEquals(square.bb.singleSquare, Some(square))
-    }
 
   test("count has the same value as squares.size"):
-    forAll { (bb: Bitboard) =>
+    forAll: (bb: Bitboard) =>
       assertEquals(bb.count, bb.squares.size)
-    }
 
   test("moreThanOne should be true when count > 1"):
-    forAll { (bb: Bitboard) =>
+    forAll: (bb: Bitboard) =>
       assertEquals(bb.moreThanOne, bb.count > 1)
-    }
 
   test("if moreThanOne then first is defined"):
-    forAll { (bb: Bitboard) =>
+    forAll: (bb: Bitboard) =>
       bb.moreThanOne ==> bb.first.isDefined
-    }
 
   test("singleSquare should be defined when count == 1"):
-    forAll { (bb: Bitboard) =>
+    forAll: (bb: Bitboard) =>
       assertEquals(bb.singleSquare.isDefined, bb.count == 1)
-    }
 
   test("fold removeFirst should return empty"):
-    forAll { (bb: Bitboard) =>
+    forAll: (bb: Bitboard) =>
       assertEquals(bb.fold(bb)((b, _) => b.removeFirst), Bitboard.empty)
-    }
 
   test("first with a function that always return None should return None"):
-    forAll { (bb: Bitboard) =>
+    forAll: (bb: Bitboard) =>
       assertEquals(bb.first(_ => None), None)
-    }
 
   test("first with a function that always return Some should return the first square"):
-    forAll { (bb: Bitboard) =>
+    forAll: (bb: Bitboard) =>
       assertEquals(bb.first(Some(_)), bb.first)
-    }
 
   test("first returns the correct square"):
-    forAll { (xs: Set[Square], x: Square) =>
+    forAll: (xs: Set[Square], x: Square) =>
       def f = (p: Square) => if p == x then Some(p) else None
       Bitboard(xs + x).first(f) == Some(x)
-    }
+
   test("bitboard created by set of square should contains and only contains those square"):
-    forAll { (xs: Set[Square]) =>
+    forAll: (xs: Set[Square]) =>
       val bb = Bitboard(xs)
       assertEquals(xs.forall(bb.contains), true)
       assertEquals(xs.size, bb.count)
-    }
 
   test("apply set of square should be the same as using addSquare"):
-    forAll { (xs: Set[Square]) =>
+    forAll: (xs: Set[Square]) =>
       val bb  = Bitboard(xs)
       val bb2 = xs.foldLeft(Bitboard.empty)(_ addSquare _)
       assertEquals(bb, bb2)
-    }
 
   test("addSquare andThen removeSquare should be the same as identity"):
-    forAll { (bb: Bitboard, square: Square) =>
+    forAll: (bb: Bitboard, square: Square) =>
       !bb.contains(square) ==> assertEquals(bb.addSquare(square).removeSquare(square), bb)
-    }
 
   test("apply(Set[square]).squares.toSet == Set[square]"):
-    forAll { (xs: Set[Square]) =>
+    forAll: (xs: Set[Square]) =>
       val result = Bitboard(xs).squares.toSet
       assertEquals(result, xs)
-    }
 
   test("nonEmpty bitboard should have at least one square"):
-    forAll { (bb: Bitboard) =>
+    forAll: (bb: Bitboard) =>
       assertEquals(bb.nonEmpty, bb.first.isDefined)
-    }
 
   test("first should be the minimum of squares"):
-    forAll { (bb: Bitboard) =>
+    forAll: (bb: Bitboard) =>
       assertEquals(bb.first, bb.squares.minByOption(_.value))
-    }
 
   test("intersects should be true when the two bitboards have at least one common square"):
-    forAll { (b1: Bitboard, b2: Bitboard, p: Square) =>
+    forAll: (b1: Bitboard, b2: Bitboard, p: Square) =>
       b1.addSquare(p).intersects(b2.addSquare(p))
-    }
 
   test("intersects and set intersection should be consistent"):
-    forAll { (s1: Set[Square], s2: Set[Square]) =>
+    forAll: (s1: Set[Square], s2: Set[Square]) =>
       val b1 = Bitboard(s1)
       val b2 = Bitboard(s2)
       val s  = s1 intersect s2
       b1.intersects(b2) == s.nonEmpty
-    }
 
   test("isDisjoint should be false when the two bitboards have at least common square"):
-    forAll { (b1: Bitboard, b2: Bitboard, p: Square) =>
+    forAll: (b1: Bitboard, b2: Bitboard, p: Square) =>
       !b1.addSquare(p).isDisjoint(b2.addSquare(p))
-    }
 
   test("isDisjoint and intersects always return the opposite value"):
-    forAll { (b1: Bitboard, b2: Bitboard) =>
+    forAll: (b1: Bitboard, b2: Bitboard) =>
       b1.isDisjoint(b2) == !b1.intersects(b2)
-    }
+
+  property("forall"):
+    forAll: (b: Bitboard, f: Square => Boolean) =>
+      b.forall(f) == b.squares.forall(f)
+
+  property("exists"):
+    forAll: (b: Bitboard, f: Square => Boolean) =>
+      b.exists(f) == b.squares.exists(f)
+
+  property("map"):
+    forAll: (b: Bitboard, f: Square => Int) =>
+      b.map(f) == b.squares.map(f)
+
+  property("flatMap"):
+    forAll: (b: Bitboard, f: Square => Option[Int]) =>
+      b.flatMap(f) == b.squares.flatMap(f)
+
+  property("filter"):
+    forAll: (b: Bitboard, f: Square => Boolean) =>
+      b.filter(f) == b.squares.filter(f)
+
+  property("first"):
+    forAll: (b: Bitboard, f: Square => Option[Int]) =>
+      b.first(f) == b.squares.map(f).find(_.isDefined).flatten
+
+  property("foreach"):
+    forAll: (b: Bitboard, f: Square => Int) =>
+      var s1 = 0L
+      var s2 = 0L
+      b.foreach(x => s1 += f(x).toLong)
+      b.squares.foreach(x => s2 += f(x).toLong)
+      s1 == s2


### PR DESCRIPTION
Add more helper functions for `OpaqueBitboard`, such as: `map`, `filter`, `forall`. So, we don't need to do something like `bitboard.squares.forall` anymore, we can just do `bitboard.forall` directly.

Also with these functions, we can obmit bb.squares in for comprehension.