### PR TITLE
optimize Divider.mixedness

### DIFF
--- a/src/main/scala/Divider.scala
+++ b/src/main/scala/Divider.scala
@@ -88,4 +88,4 @@ object Divider:
   private def mixedness(board: Board): Int =
     mixednessRegions.foldLeft(0):
       case (acc, (region, y)) =>
-        acc + board.byColor.map(c => (c & region).count).reduce(score(y))
+        acc + board.byColor.mapReduce(c => (c & region).count)(score(y))

--- a/src/main/scala/Divider.scala
+++ b/src/main/scala/Divider.scala
@@ -77,11 +77,16 @@ object Divider:
 
       case _ => 0
 
-  private def mixedness(board: Board): Int = {
+  private val mixednessRegions: List[Bitboard] = {
     val smallSquare = 0x0303L.bb
     for
       y <- 0 to 6
       x <- 0 to 6
       region = smallSquare << (x + 8 * y)
-    yield board.byColor.map(c => (c & region).count).reduce(score(y + 1))
-  }.sum
+    yield region
+  }.toList
+
+  private def mixedness(board: Board): Int =
+    mixednessRegions.foldLeft(0): (acc, region) =>
+      val y = region.first.get.rank.index + 1
+      acc + board.byColor.map(c => (c & region).count).reduce(score(y))

--- a/src/main/scala/Divider.scala
+++ b/src/main/scala/Divider.scala
@@ -2,6 +2,7 @@ package chess
 
 import cats.syntax.all.*
 import bitboard.Bitboard
+import bitboard.Bitboard.bb
 import scala.annotation.switch
 
 case class Division(middle: Option[Ply], end: Option[Ply], plies: Ply):
@@ -50,7 +51,7 @@ object Divider:
     (Bitboard.firstRank & board.white).count < 4 ||
       (Bitboard.lastRank & board.black).count < 4
 
-  private def score(white: Int, black: Int, y: Int): Int =
+  private def score(y: Int)(white: Int, black: Int): Int =
     ((white, black): @switch) match
       case (0, 0) => 0
 
@@ -76,26 +77,11 @@ object Divider:
 
       case _ => 0
 
-  private val mixednessRegions: List[List[Square]] = {
+  private def mixedness(board: Board): Int = {
+    val smallSquare = 0x0303L.bb
     for
-      y <- Rank.all.take(7)
-      x <- File.all.take(7)
-    yield {
-      for
-        dy   <- 0 to 1
-        dx   <- 0 to 1
-        file <- x.offset(dx)
-        rank <- y.offset(dy)
-      yield Square(file, rank)
-    }.toList
-  }.toList
-
-  private def mixedness(board: Board): Int =
-    mixednessRegions.foldLeft(0): (mix, region) =>
-      var white = 0
-      var black = 0
-      region.foreach: s =>
-        board(s).foreach: v =>
-          if v is White then white = white + 1
-          else black = black + 1
-      mix + score(white, black, region.head.rank.index + 1)
+      y <- 0 to 6
+      x <- 0 to 6
+      region = smallSquare << (x + 8 * y)
+    yield board.byColor.map(c => (c & region).count).reduce(score(y + 1))
+  }.sum

--- a/src/main/scala/Divider.scala
+++ b/src/main/scala/Divider.scala
@@ -2,7 +2,6 @@ package chess
 
 import cats.syntax.all.*
 import bitboard.Bitboard
-import bitboard.Bitboard.bb
 import scala.annotation.switch
 
 case class Division(middle: Option[Ply], end: Option[Ply], plies: Ply):
@@ -77,8 +76,8 @@ object Divider:
 
       case _ => 0
 
-  private val mixednessRegions: List[(Bitboard, Int)] = {
-    val smallSquare = 0x0303L.bb
+  private val mixednessRegions: List[(Long, Int)] = {
+    val smallSquare = 0x0303L
     for
       y <- 0 to 6
       x <- 0 to 6

--- a/src/main/scala/Divider.scala
+++ b/src/main/scala/Divider.scala
@@ -77,16 +77,15 @@ object Divider:
 
       case _ => 0
 
-  private val mixednessRegions: List[Bitboard] = {
+  private val mixednessRegions: List[(Bitboard, Int)] = {
     val smallSquare = 0x0303L.bb
     for
       y <- 0 to 6
       x <- 0 to 6
-      region = smallSquare << (x + 8 * y)
-    yield region
+    yield (smallSquare << (x + 8 * y), y + 1)
   }.toList
 
   private def mixedness(board: Board): Int =
-    mixednessRegions.foldLeft(0): (acc, region) =>
-      val y = region.first.get.rank.index + 1
-      acc + board.byColor.map(c => (c & region).count).reduce(score(y))
+    mixednessRegions.foldLeft(0):
+      case (acc, (region, y)) =>
+        acc + board.byColor.map(c => (c & region).count).reduce(score(y))


### PR DESCRIPTION
Before:
```
[info] PlayBench.divider  thrpt   45  21.868 ± 1.357  ops/s
```

After, first attempt:
```
[info] PlayBench.divider  thrpt   45  33.767 ± 1.497  ops/s
```

Additionally, precomputing mixedness regions again:
```
[info] PlayBench.divider  thrpt   45  51.566 ± 4.220  ops/s
```

Additionally, using `mapReduce`:
```
[info] PlayBench.divider  thrpt   45  65.580 ± 3.128  ops/s
```

Additionally, using `Long` instead of `Bitboard` region masks:
```
[info] PlayBench.divider  thrpt   45  91.231 ± 5.867  ops/s
```