### PR TITLE
Optimize ByColor flatMap/flatten

### DIFF
--- a/src/main/scala/ByColor.scala
+++ b/src/main/scala/ByColor.scala
@@ -1,11 +1,9 @@
 package chess
 
-import cats.{ Applicative, Eq, Functor, Monoid }
+import cats.{ Applicative, Eq, Eval, Functor, Monoid, Traverse }
 import cats.syntax.all.*
 import scala.annotation.targetName
 import alleycats.Zero
-import cats.Traverse
-import cats.Eval
 
 case class ByColor[A](white: A, black: A):
 

--- a/src/main/scala/ByColor.scala
+++ b/src/main/scala/ByColor.scala
@@ -5,7 +5,7 @@ import cats.syntax.all.*
 import scala.annotation.targetName
 import alleycats.Zero
 
-case class ByColor[A](white: A, black: A) extends ByColorSyntax:
+case class ByColor[A](white: A, black: A):
 
   inline def apply(inline color: Color) = if color.white then white else black
 
@@ -127,12 +127,13 @@ object ByColor:
     def ap[A, B](ff: ByColor[A => B])(fa: ByColor[A]): ByColor[B] =
       ByColor(ff.white(fa.white), ff.black(fa.black))
 
-trait ByColorSyntax:
-
   extension [F[_], A](bc: ByColor[F[A]])
 
-    def mapN[Z](f: (A, A) => Z)(using functor: Functor[F], semigroupal: Semigroupal[F]): F[Z] =
+    def mapN[Z](f: (A, A) => Z)(using Functor[F], Semigroupal[F]): F[Z] =
       Semigroupal.map2(bc.white, bc.black)(f)
 
     def flatMapN[Z](f: (A, A) => F[Z])(using flatMap: FlatMap[F]): F[Z] =
       flatMap.flatMap2(bc.white, bc.black)(f)
+
+    def tupled(using Applicative[F]): F[(A, A)] =
+      (bc.white, bc.black).tupled

--- a/src/test/scala/ByColorLawsTests.scala
+++ b/src/test/scala/ByColorLawsTests.scala
@@ -1,11 +1,11 @@
 package chess
 
-import cats.laws.discipline.FunctorTests
 import munit.DisciplineSuite
 import org.scalacheck.*
 import Arbitraries.given
-import cats.laws.discipline.TraverseTests
+import cats.laws.discipline.{ ApplicativeTests, FunctorTests, TraverseTests }
 
 class ByColorLawsTest extends DisciplineSuite:
   checkAll("ByColor.FunctorLaws", FunctorTests[ByColor].functor[Int, Int, String])
   checkAll("ByColor.TraverseLaws", TraverseTests[ByColor].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("ByColor.ApplicativeLaws", ApplicativeTests[ByColor].applicative[Int, Int, String])

--- a/src/test/scala/ByColorTest.scala
+++ b/src/test/scala/ByColorTest.scala
@@ -87,6 +87,10 @@ class ByColorTest extends ScalaCheckSuite:
     forAll: (bc: ByColor[Option[Int]]) =>
       bc.sequence == (bc.white, bc.black).mapN(ByColor(_, _))
 
+  test("tupled == mapN.identity"):
+    forAll: (bc: ByColor[Option[Int]]) =>
+      bc.mapN((_, _)) == bc.tupled
+
   test("findColor && exists"):
     forAll: (bc: ByColor[Int], f: Int => Boolean) =>
       bc.findColor(f).isDefined == bc.all.exists(f)

--- a/src/test/scala/ByColorTest.scala
+++ b/src/test/scala/ByColorTest.scala
@@ -83,6 +83,10 @@ class ByColorTest extends ScalaCheckSuite:
     forAll: (bc: ByColor[Int], f: Int => Boolean) =>
       bc.exists(f) == bc.all.exists(f)
 
+  test("sequence"):
+    forAll: (bc: ByColor[Option[Int]]) =>
+      bc.sequence == (bc.white, bc.black).mapN(ByColor(_, _))
+
   test("findColor && exists"):
     forAll: (bc: ByColor[Int], f: Int => Boolean) =>
       bc.findColor(f).isDefined == bc.all.exists(f)

--- a/src/test/scala/ByColorTest.scala
+++ b/src/test/scala/ByColorTest.scala
@@ -52,6 +52,10 @@ class ByColorTest extends ScalaCheckSuite:
     forAll: (bc: ByColor[Int], f: Int => Int) =>
       bc.update(White, f).update(Black, f) == bc.update(Black, f).update(White, f)
 
+  test("faltten == flatMap(identity)"):
+    forAll: (bc: ByColor[Option[Int]]) =>
+      bc.flatten == bc.flatMap(identity)
+
   test("fold"):
     forAll: (bc: ByColor[Int], init: String, f: (String, Int) => String) =>
       bc.fold(init)(f) == bc.all.foldLeft(init)(f)

--- a/src/test/scala/ByColorTest.scala
+++ b/src/test/scala/ByColorTest.scala
@@ -56,6 +56,10 @@ class ByColorTest extends ScalaCheckSuite:
     forAll: (bc: ByColor[Option[Int]]) =>
       bc.flatten == bc.flatMap(identity)
 
+  test("flatMap == all.flatMap"):
+    forAll: (bc: ByColor[Int], f: Int => Option[String]) =>
+      bc.flatMap(f) == bc.all.flatMap(f(_))
+
   test("fold"):
     forAll: (bc: ByColor[Int], init: String, f: (String, Int) => String) =>
       bc.fold(init)(f) == bc.all.foldLeft(init)(f)


### PR DESCRIPTION
benchmarks code:
```scala
package benchmarks

import org.openjdk.jmh.annotations.*
import org.openjdk.jmh.infra.Blackhole
import java.util.concurrent.TimeUnit
import chess.ByColor

@State(Scope.Thread)
@BenchmarkMode(Array(Mode.Throughput))
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
@Fork(value = 3)
@Threads(value = 1)
class ByColorBench:

  // the unit of CPU work per iteration
  private[this] val Work: Long = 10

  case class Game(pgn: String)

  var byColor: ByColor[Game] = _
  var byColorO: ByColor[Option[Game]] = _
  def f(s: String): Option[String] =
    if s.size % 3 == 0 then None
    else Some(s)

  @Setup
  def setup() =
    byColor = ByColor(Game("foo"), Game("bar"))
    byColorO = ByColor(Some(Game("foo")), Some(Game("bar")))

  @Benchmark
  def byColorFlatMap =
    Blackhole.consumeCPU(Work)
    byColor.flatMap(g => f(g.pgn).map(Game(_)))

  @Benchmark
  def allFlatMap =
    Blackhole.consumeCPU(Work)
    byColor.all.flatMap(g => f(g.pgn).map(Game(_)))

  @Benchmark
  def byColorFlatten =
    Blackhole.consumeCPU(Work)
    byColorO.flatten

  @Benchmark
  def allFlatten =
    Blackhole.consumeCPU(Work)
    byColorO.all.flatten
```
results:
```
[info] Benchmark                            Mode  Cnt       Score     Error   Units
[info] ByColorBench.allFlatMap             thrpt   45   99880.913 ± 516.563  ops/ms
[info] ByColorBench.allFlatten             thrpt   45   61322.261 ± 178.359  ops/ms
[info] ByColorBench.byColorFlatMap         thrpt   45  117163.184 ± 418.543  ops/ms
[info] ByColorBench.byColorFlatten         thrpt   45   93482.812 ± 413.525  ops/ms
[info] Benchmark result is saved to jmh-result.json
```