### PR TITLE
Specialize ByColor & ByRole for bitboard.Board

### DIFF
--- a/src/main/scala/bitboard/Board.scala
+++ b/src/main/scala/bitboard/Board.scala
@@ -8,7 +8,7 @@ import Bitboard.*
 // Chess board representation
 case class Board(
     occupied: Bitboard,
-    byColor: ByColor[Bitboard],
+    byColor: ByColor,
     byRole: ByRole[Bitboard]
 ):
   val white   = byColor.white
@@ -223,3 +223,31 @@ object Board:
         case Color.Black => black |= position
 
     Board(occupied, ByColor(white, black), ByRole(pawns, knights, bishops, rooks, queens, kings))
+
+case class ByColor(white: Bitboard, black: Bitboard):
+
+  inline def apply(inline color: Color) = if color.white then white else black
+
+  inline def findColor(pred: Bitboard => Boolean): Option[Color] =
+    if pred(white) then White.some
+    else if pred(black) then Black.some
+    else None
+
+  def foreach[U](f: Bitboard => U): Unit =
+    f(white)
+    f(black)
+
+  def foreach[U](f: (Color, Bitboard) => U): Unit =
+    f(White, white)
+    f(Black, black)
+
+  inline def update(inline color: Color, f: Bitboard => Bitboard): ByColor =
+    if color.white then copy(white = f(white))
+    else copy(black = f(black))
+
+  def mapReduce[B, C](f: Bitboard => B)(r: (B, B) => C): C = r(f(white), f(black))
+
+  def map(f: Bitboard => Bitboard): ByColor = ByColor(f(white), f(black))
+
+object ByColor:
+  inline def fill(a: Bitboard): ByColor = ByColor(a, a)


### PR DESCRIPTION
Another optimization with the price of duplicated code. The result is below, but lets talk about why this is better. Generics is awesome in general, but it's quite bad for performance. It's required allocation and boxing when working with primitive. In our case ByColor[Bitboard] will required 2 extra allocations, which is not much but still 🤷 .

Another thing is about `Monomorphic` and `megamorphic` 🤯 , which this [article](https://gist.github.com/djspiewak/464c11307cabc80171c90397d4ec34ef) and its reference are really good sources.
Some code for the demonstration:

```scala
//> using scala 3.3.0

package example

object Main:
  val b1 = ByColorG(Bitboard(1))
  val b2 = ByColor(Bitboard(1))

  def main(args: Array[String]): Unit =
    println(b1)
    println(b2)

case class ByColorG[T](x: T)
case class ByColor(x: Bitboard)
```
The main object will be compiled as:

```java
public final class Main$
implements Serializable {
    private static final ByColorG b1;
    private static final ByColor b2;
    public static final Main$ MODULE$;

    private Main$() {
    }

    static {
        MODULE$ = new Main$();
        b1 = ByColorG$.MODULE$.apply(BoxesRunTime.boxToLong((long)FinalCaseClass.package.Bitboard$.MODULE$.apply(1L)));
        b2 = ByColor$.MODULE$.apply(FinalCaseClass.package.Bitboard$.MODULE$.apply(1L));
    }

    private Object writeReplace() {
        return new ModuleSerializationProxy(Main$.class);
    }

    public ByColorG<Object> b1() {
        return b1;
    }

    public ByColor b2() {
        return b2;
    }

    public void main(String[] args) {
        Predef$.MODULE$.println(this.b1());
        Predef$.MODULE$.println((Object)this.b2());
    }
}
```
More of the de-compiled code is [here](https://gist.github.com/lenguyenthanh/0ddaa96fed4709f3ac342b159387f81a)

![Screenshot 2023-07-18 at 09-28-19 JMH Visualizer](https://github.com/lichess-org/scalachess/assets/437967/9fab360b-f094-4246-99d4-645314e217b2)
