### PR TITLE
Produce bytecode version 17

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,17 +22,16 @@ lazy val scalachess = Project("scalachess", file(".")).settings(
   scalacOptions := Seq(
     "-encoding",
     "utf-8",
-    // "-rewrite",
     "-source:future-migration",
     "-indent",
     "-feature",
     "-language:postfixOps",
-    "-Xtarget:12",
-    "-Wunused:all"
+    "-Wunused:all",
     // "-Werror"
     // Warnings as errors!
     /* "-Xfatal-warnings" */
-  )
+  ),
+  scalacOptions ++= Seq("-java-output-version", "17")
 )
 
 ThisBuild / organization      := "org.lichess"


### PR DESCRIPTION
It works, I use `javap -verbose target/scala-3.3.0/classes/chess/Color.class` to verify. We can see the major versions has changed from `56` (jdk 12) to `61` jdk 17. We currently use `"-Xtarget:12"`.

```
Before
  minor version: 0
  major version: 56

After:
  minor version: 0
  major version: 61
```