### PR TITLE
Optimize Hash and isRepetition function

### DIFF
--- a/bench/src/main/scala/benchmarks/HashBench.scala
+++ b/bench/src/main/scala/benchmarks/HashBench.scala
@@ -37,3 +37,17 @@ class HashBench:
       Blackhole.consumeCPU(Work)
       Hash(x)
     bh.consume(result)
+
+  @Benchmark
+  def repetition5(bh: Blackhole) =
+    var result = situations.map: x =>
+      Blackhole.consumeCPU(Work)
+      x.board.history.fivefoldRepetition
+    bh.consume(result)
+
+  @Benchmark
+  def repetition3(bh: Blackhole) =
+    var result = situations.map: x =>
+      Blackhole.consumeCPU(Work)
+      x.board.history.threefoldRepetition
+    bh.consume(result)

--- a/src/main/scala/Drop.scala
+++ b/src/main/scala/Drop.scala
@@ -1,9 +1,7 @@
 package chess
 
 import cats.syntax.option.none
-
 import chess.format.Uci
-import cats.kernel.Monoid
 
 case class Drop(
     piece: Piece,
@@ -35,9 +33,7 @@ case class Drop(
     board updateHistory { h =>
       val basePositionHashes =
         if h.positionHashes.value.isEmpty then Hash(situationBefore) else h.positionHashes
-      h.copy(positionHashes =
-        Monoid[PositionHash].combine(Hash(Situation(board, !piece.color)), basePositionHashes)
-      )
+      h.copy(positionHashes = Hash(Situation(board, !piece.color)).combine(basePositionHashes))
     }
 
   def afterWithLastMove =

--- a/src/main/scala/Hash.scala
+++ b/src/main/scala/Hash.scala
@@ -4,13 +4,17 @@ import cats.Monoid
 import Castles.*
 
 opaque type PositionHash = Array[Byte]
-object PositionHash extends TotalWrapper[PositionHash, Array[Byte]]:
+object PositionHash:
+  def apply(value: Array[Byte]): PositionHash = value
   given Monoid[PositionHash] with
     def combine(p1: PositionHash, p2: PositionHash) = p1 ++ p2
     val empty                                       = Array.empty
 
+  extension (p: PositionHash) def value: Array[Byte] = p
+
 opaque type Hash = Int
-object Hash extends OpaqueInt[Hash]:
+object Hash:
+  def apply(value: Int): Hash = value
   extension (size: Hash)
     def apply(situation: Situation): PositionHash = PositionHash:
       val l = Hash.get(situation, Hash.polyglotTable)
@@ -28,6 +32,7 @@ object Hash extends OpaqueInt[Hash]:
     def hexToLong(s: String): Long =
       (java.lang.Long.parseLong(s.substring(start, start + 8), 16) << 32) |
         java.lang.Long.parseLong(s.substring(start + 8, start + 16), 16)
+
     val whiteTurnMask       = hexToLong(ZobristTables.whiteTurnMask)
     val actorMasks          = ZobristTables.actorMasks.map(hexToLong)
     val castlingMasks       = ZobristTables.castlingMasks.map(hexToLong)

--- a/src/main/scala/Hash.scala
+++ b/src/main/scala/Hash.scala
@@ -10,7 +10,23 @@ object PositionHash:
     def combine(p1: PositionHash, p2: PositionHash) = p1 ++ p2
     val empty                                       = Array.empty
 
-  extension (p: PositionHash) def value: Array[Byte] = p
+  extension (p: PositionHash)
+    def value: Array[Byte] = p
+    def isRepetition(times: Int) =
+      if times <= 1 then true
+      else if p.length <= (times - 1) * 4 * Hash.size then false
+      else
+        // compare only hashes for positions with the same side to move
+        var i     = Hash.size * 2
+        var count = 0
+        val x     = p(0)
+        val y     = p(1)
+        val z     = p(2)
+        while i <= p.length - Hash.size && count < times - 1
+        do
+          if x == p(i) && y == p(i + 1) && z == p(i + 2) then count += 1
+          i += Hash.size * 2
+        count == times - 1
 
 opaque type Hash = Int
 object Hash:

--- a/src/main/scala/Hash.scala
+++ b/src/main/scala/Hash.scala
@@ -1,17 +1,16 @@
 package chess
 
-import cats.Monoid
 import Castles.*
 
 opaque type PositionHash = Array[Byte]
 object PositionHash:
   def apply(value: Array[Byte]): PositionHash = value
-  given Monoid[PositionHash] with
-    def combine(p1: PositionHash, p2: PositionHash) = p1 ++ p2
-    val empty                                       = Array.empty
+  val empty: PositionHash                     = Array.empty
 
   extension (p: PositionHash)
-    def value: Array[Byte] = p
+    def value: Array[Byte]                                = p
+    inline def isEmpty: Boolean                           = p.length == 0
+    inline def combine(other: PositionHash): PositionHash = p ++ other
     def isRepetition(times: Int) =
       if times <= 1 then true
       else if p.length <= (times - 1) * 4 * Hash.size then false

--- a/src/main/scala/History.scala
+++ b/src/main/scala/History.scala
@@ -64,7 +64,7 @@ case class History(
 
   override def toString =
     val positions = (positionHashes.value grouped Hash.size).toList
-    s"${lastMove.fold("-")(_.uci)} ${PositionHash.from(positions).map(Hash.debug).mkString(" ")}"
+    s"${lastMove.fold("-")(_.uci)} ${positions.map(PositionHash.apply).map(Hash.debug).mkString(" ")}"
 
 object History:
 

--- a/src/main/scala/History.scala
+++ b/src/main/scala/History.scala
@@ -1,7 +1,6 @@
 package chess
 
 import format.Uci
-import cats.kernel.Monoid
 
 // Checks received by the respective side.
 case class CheckCount(white: Int = 0, black: Int = 0):
@@ -18,7 +17,7 @@ case class CheckCount(white: Int = 0, black: Int = 0):
 
 case class History(
     lastMove: Option[Uci] = None,
-    positionHashes: PositionHash = Monoid[PositionHash].empty,
+    positionHashes: PositionHash = PositionHash.empty,
     castles: Castles = Castles.init,
     checkCount: CheckCount = CheckCount(0, 0),
     unmovedRooks: UnmovedRooks,
@@ -27,22 +26,8 @@ case class History(
 
   def setHalfMoveClock(v: HalfMoveClock) = copy(halfMoveClock = v)
 
-  // private def isRepetition(times: Int) =
-  //   positionHashes.value.length > (times - 1) * 4 * Hash.size && {
-  //     // compare only hashes for positions with the same side to move
-  //     val positions = positionHashes.value.sliding(Hash.size, 2 * Hash.size).toList
-  //     positions.headOption match
-  //       case Some(Array(x, y, z)) =>
-  //         (positions count {
-  //           case Array(x2, y2, z2) => x == x2 && y == y2 && z == z2
-  //           case _                 => false
-  //         }) >= times
-  //       case _ => times <= 1
-  //   }
-
   inline def threefoldRepetition = positionHashes.isRepetition(3)
-
-  inline def fivefoldRepetition = positionHashes.isRepetition(5)
+  inline def fivefoldRepetition  = positionHashes.isRepetition(5)
 
   inline def canCastle(inline color: Color)                    = castles can color
   inline def canCastle(inline color: Color, inline side: Side) = castles.can(color, side)
@@ -76,7 +61,7 @@ object History:
       lastMove = lastMove flatMap Uci.apply,
       castles = Castles(castles),
       unmovedRooks = UnmovedRooks.corners,
-      positionHashes = Monoid[PositionHash].empty
+      positionHashes = PositionHash.empty
     )
 
   def castle(color: Color, kingSide: Boolean, queenSide: Boolean) =

--- a/src/main/scala/History.scala
+++ b/src/main/scala/History.scala
@@ -27,22 +27,22 @@ case class History(
 
   def setHalfMoveClock(v: HalfMoveClock) = copy(halfMoveClock = v)
 
-  private def isRepetition(times: Int) =
-    positionHashes.value.length > (times - 1) * 4 * Hash.size && {
-      // compare only hashes for positions with the same side to move
-      val positions = positionHashes.value.sliding(Hash.size, 2 * Hash.size).toList
-      positions.headOption match
-        case Some(Array(x, y, z)) =>
-          (positions count {
-            case Array(x2, y2, z2) => x == x2 && y == y2 && z == z2
-            case _                 => false
-          }) >= times
-        case _ => times <= 1
-    }
+  // private def isRepetition(times: Int) =
+  //   positionHashes.value.length > (times - 1) * 4 * Hash.size && {
+  //     // compare only hashes for positions with the same side to move
+  //     val positions = positionHashes.value.sliding(Hash.size, 2 * Hash.size).toList
+  //     positions.headOption match
+  //       case Some(Array(x, y, z)) =>
+  //         (positions count {
+  //           case Array(x2, y2, z2) => x == x2 && y == y2 && z == z2
+  //           case _                 => false
+  //         }) >= times
+  //       case _ => times <= 1
+  //   }
 
-  inline def threefoldRepetition = isRepetition(3)
+  inline def threefoldRepetition = positionHashes.isRepetition(3)
 
-  inline def fivefoldRepetition = isRepetition(5)
+  inline def fivefoldRepetition = positionHashes.isRepetition(5)
 
   inline def canCastle(inline color: Color)                    = castles can color
   inline def canCastle(inline color: Color, inline side: Side) = castles.can(color, side)

--- a/src/main/scala/Move.scala
+++ b/src/main/scala/Move.scala
@@ -1,8 +1,7 @@
 package chess
 
 import chess.format.Uci
-import cats.syntax.option.*
-import cats.Monoid
+import cats.syntax.all.*
 
 case class Move(
     piece: Piece,
@@ -86,13 +85,11 @@ case class Move(
     // castling rights and en-passant rights.
     board updateHistory { h =>
       lazy val positionHashesOfSituationBefore =
-        if h.positionHashes.value.isEmpty then Hash(situationBefore) else h.positionHashes
+        if h.positionHashes.isEmpty then Hash(situationBefore) else h.positionHashes
       val resetsPositionHashes = board.variant.isIrreversible(this)
       val basePositionHashes =
-        if resetsPositionHashes then Monoid[PositionHash].empty else positionHashesOfSituationBefore
-      h.copy(positionHashes =
-        Monoid[PositionHash].combine(Hash(Situation(board, !piece.color)), basePositionHashes)
-      )
+        if resetsPositionHashes then PositionHash.empty else positionHashesOfSituationBefore
+      h.copy(positionHashes = Hash(Situation(board, !piece.color)).combine(basePositionHashes))
     }
 
   def applyVariantEffect: Move = before.variant addVariantEffect this

--- a/src/main/scala/format/FenReader.scala
+++ b/src/main/scala/format/FenReader.scala
@@ -4,7 +4,6 @@ package format
 import cats.syntax.all.*
 import variant.{ Standard, Variant }
 import variant.Crazyhouse.Pockets
-import cats.kernel.Monoid
 import ornicar.scalalib.zeros.given
 import bitboard.Bitboard
 import bitboard.Board as BBoard
@@ -58,7 +57,7 @@ trait FenReader:
       situation withHistory:
         val history = History(
           lastMove = enpassantMove,
-          positionHashes = Monoid[PositionHash].empty,
+          positionHashes = PositionHash.empty,
           castles = castles,
           unmovedRooks = unmovedRooks
         )

--- a/src/test/scala/ChessTest.scala
+++ b/src/test/scala/ChessTest.scala
@@ -9,7 +9,6 @@ import chess.format.{ EpdFen, Fen, Visual }
 import chess.format.pgn.PgnStr
 import chess.variant.Variant
 import bitboard.Board as BBoard
-import cats.kernel.Monoid
 import chess.format.Uci
 import chess.variant.Chess960
 
@@ -115,7 +114,7 @@ trait ChessTest extends Specification with EitherMatchers:
 
   def defaultHistory(
       lastMove: Option[Uci] = None,
-      positionHashes: PositionHash = Monoid[PositionHash].empty,
+      positionHashes: PositionHash = PositionHash.empty,
       castles: Castles = Castles.init,
       checkCount: CheckCount = CheckCount(0, 0),
       unmovedRooks: UnmovedRooks = UnmovedRooks.corners,

--- a/src/test/scala/HistoryTest.scala
+++ b/src/test/scala/HistoryTest.scala
@@ -1,14 +1,12 @@
 package chess
 
-import cats.kernel.Monoid
-
 class HistoryTest extends ChessTest:
 
   "threefold repetition" should:
     def toHash(a: Int) = PositionHash(Array(a.toByte, 0.toByte, 0.toByte))
     def makeHistory(positions: List[Int]) =
       (positions map toHash).foldLeft(defaultHistory()) { (history, hash) =>
-        history.copy(positionHashes = Monoid[PositionHash].combine(hash, history.positionHashes))
+        history.copy(positionHashes = hash.combine(history.positionHashes))
       }
     "empty history" in:
       defaultHistory().threefoldRepetition must_== false


### PR DESCRIPTION
Before

```
[info] HashBench.hashes       thrpt   45  746.230 ± 15.666  ops/s
[info] HashBench.repetition3  thrpt   45  709.714 ± 26.750  ops/s
[info] HashBench.repetition5  thrpt   45  808.189 ± 32.930  ops/s
```

After removing newtypes & change algorithm

```
[info] HashBench.hashes       thrpt   45    748.412 ±  19.580  ops/s
[info] HashBench.repetition3  thrpt   45  12099.058 ± 232.333  ops/s
[info] HashBench.repetition5  thrpt   45  12276.818 ± 187.127  ops/s
```

Removing Monoid

```
[info] HashBench.hashes       thrpt   45    758.422 ±  33.644  ops/s
[info] HashBench.repetition3  thrpt   45  12476.803 ± 114.103  ops/s
[info] HashBench.repetition5  thrpt   45  12865.016 ± 195.063  ops/s
```

[Full benchmark](https://gist.github.com/lenguyenthanh/9380c5422ca40efedb567c32de1f4793)