### PR TITLE
Optimize pgn render

### DIFF
--- a/src/main/scala/Castles.scala
+++ b/src/main/scala/Castles.scala
@@ -1,7 +1,6 @@
 package chess
 
 import cats.syntax.all.*
-
 import bitboard.Bitboard
 import Square.*
 
@@ -86,8 +85,10 @@ object Castles:
       blackKingSide.at(Black.kingSide) |
       blackQueenSide.at(Black.queenSide)
 
-  def apply(bb: Bitboard): Castles                       = bb.value
-  inline def apply(inline xs: Iterable[Square]): Castles = xs.foldLeft(none)((b, s) => b | s.bl)
+  def apply(l: Long): Castles = init & l
+
+  @targetName("applyBitboard")
+  def apply(bb: Bitboard): Castles = init & bb.value
 
   def apply(str: String): Castles = str match
     case "-" => none

--- a/src/main/scala/format/pgn/Pgn.scala
+++ b/src/main/scala/format/pgn/Pgn.scala
@@ -123,7 +123,9 @@ object Move:
   val noDoubleLineBreakRegex = "(\r?\n){2,}".r
 
   def render(cm: List[Comment]): String =
-    cm.foldLeft("")((acc, x) => acc ++ s" { ${noDoubleLineBreak(x.value)} }")
+    val builder = new StringBuilder
+    cm.foreach(x => builder.append(" { ").append(x.value).append(" }"))
+    builder.toString
 
   def noDoubleLineBreak(txt: String) =
     noDoubleLineBreakRegex.replaceAllIn(txt, "\n")

--- a/src/test/scala/format/pgn/PgnHelper.scala
+++ b/src/test/scala/format/pgn/PgnHelper.scala
@@ -1,0 +1,57 @@
+package chess
+package format.pgn
+
+import cats.syntax.all.*
+import MoveOrDrop.*
+
+object PgnHelper:
+  case class Context(sit: Situation, ply: Ply)
+
+  extension (d: PgnNodeData)
+    def toMove(context: Context): Option[(Situation, Move)] =
+      d.san(context.sit)
+        .toOption
+        .map(x =>
+          (
+            x.situationAfter,
+            Move(
+              ply = context.ply,
+              san = x.toSanStr,
+              comments = d.comments,
+              glyphs = d.glyphs,
+              opening = None,
+              result = None,
+              secondsLeft = None,
+              variationComments = d.variationComments
+            )
+          )
+        )
+
+  extension (tree: ParsedPgnTree)
+    def toPgn(game: Game): Option[PgnTree] =
+      tree.mapAccumlOption_(Context(game.situation, game.ply + 1)): (ctx, d) =>
+        d.toMove(ctx) match
+          case Some((sit, m)) => (Context(sit, ctx.ply.next), m.some)
+          case None           => (ctx, None)
+
+  extension (pgn: ParsedPgn)
+    def toPgn: Pgn =
+      val game = makeGame(pgn.tags)
+      Pgn(pgn.tags, pgn.initialPosition, pgn.tree.flatMap(_.toPgn(game)))
+
+    def cleanTags: ParsedPgn =
+      pgn.copy(tags = Tags.empty)
+
+  extension (pgn: PgnStr)
+    def cleanup = PgnStr:
+      pgn.value.replace("\r", "").replace("\n", " ").trim
+
+  private def makeGame(tags: Tags) =
+    val g = Game(
+      variantOption = tags(_.Variant) flatMap chess.variant.Variant.byName,
+      fen = tags.fen
+    )
+    g.copy(
+      startedAtPly = g.ply,
+      clock = tags.clockConfig map Clock.apply
+    )


### PR DESCRIPTION
Optimize `Pgn.render` by using `StringBuilder`. ~This improved speed twice, but still keep using recursion for rendering. That means we can have potential stacksafe issue (I don't see stackoverflow up to 20k nodes). I'll work on that later.~

Edit: Actually we already can have some `tailrec` after all, profiler before/after.
 
<img width="1920" alt="Screenshot 2023-07-28 at 13 08 34" src="https://github.com/lichess-org/scalachess/assets/437967/712801b0-393c-4404-97a9-b10e7ad6989f">

Before
```
[info] PgnBench.pgnRender  thrpt   45  342.884 ± 2.720  ops/s
```
After StringBuilder
```
[info] PgnBench.pgnRender  thrpt   45  760.030 ± 17.521  ops/s
```
After `tailrec`:
```
[info] PgnBench.pgnRender  thrpt   45  764.908 ± 2.781  ops/s
```

[Full benchmark](https://gist.github.com/lenguyenthanh/68f79c29eecdd7f45103d4b8cdf17c9f)