### PR TITLE
Add `lazy val san: SanStr` for Move and Drop

### DIFF
--- a/src/main/scala/Drop.scala
+++ b/src/main/scala/Drop.scala
@@ -13,11 +13,13 @@ case class Drop(
 
   inline def before = situationBefore.board
 
-  inline def situationAfter = Situation(finalizeAfter, !piece.color)
+  lazy val situationAfter = Situation(finalizeAfter, !piece.color)
+
+  lazy val san = format.pgn.Dumper(this)
 
   inline def withHistory(inline h: History) = copy(after = after withHistory h)
 
-  def finalizeAfter: Board =
+  lazy val finalizeAfter: Board =
     val board = after.variant.finalizeBoard(
       after updateHistory { h =>
         h.copy(

--- a/src/main/scala/Drop.scala
+++ b/src/main/scala/Drop.scala
@@ -2,6 +2,7 @@ package chess
 
 import cats.syntax.option.none
 import chess.format.Uci
+import chess.format.pgn.SanStr
 
 case class Drop(
     piece: Piece,
@@ -11,13 +12,9 @@ case class Drop(
     metrics: MoveMetrics = MoveMetrics.empty
 ):
 
-  inline def before = situationBefore.board
-
+  inline def before       = situationBefore.board
   lazy val situationAfter = Situation(finalizeAfter, !piece.color)
-
-  lazy val san = format.pgn.Dumper(this)
-
-  inline def withHistory(inline h: History) = copy(after = after withHistory h)
+  lazy val san: SanStr    = format.pgn.Dumper(this)
 
   lazy val finalizeAfter: Board =
     val board = after.variant.finalizeBoard(
@@ -38,7 +35,9 @@ case class Drop(
       h.copy(positionHashes = Hash(Situation(board, !piece.color)).combine(basePositionHashes))
     }
 
-  def afterWithLastMove =
+  inline def withHistory(inline h: History) = copy(after = after withHistory h)
+
+  def afterWithLastMove: Board =
     after.variant.finalizeBoard(
       after.copy(history = after.history.withLastMove(toUci)),
       toUci,

--- a/src/main/scala/Game.scala
+++ b/src/main/scala/Game.scala
@@ -44,7 +44,7 @@ case class Game(
       copy(
         situation = newSituation,
         ply = ply + 1,
-        sans = sans :+ pgn.Dumper(situation, move, newSituation),
+        sans = sans :+ move.san,
         clock = newClock.map(_.value)
       ),
       newClock.flatMap(_.compensated)
@@ -62,7 +62,7 @@ case class Game(
     copy(
       situation = newSituation,
       ply = ply + 1,
-      sans = sans :+ pgn.Dumper(drop, newSituation),
+      sans = sans :+ drop.san,
       clock = applyClock(drop.metrics, newSituation.status.isEmpty).map(_.value)
     )
 

--- a/src/main/scala/Move.scala
+++ b/src/main/scala/Move.scala
@@ -17,7 +17,8 @@ case class Move(
 ):
   inline def before = situationBefore.board
 
-  inline def situationAfter = Situation(finalizeAfter, !piece.color)
+  lazy val situationAfter = Situation(finalizeAfter, !piece.color)
+  lazy val san            = format.pgn.Dumper(this)
 
   inline def withHistory(inline h: History) = copy(after = after withHistory h)
 
@@ -25,7 +26,7 @@ case class Move(
 
   // TODO rethink about how handle castling
   // it's quite messy and error prone now
-  def finalizeAfter: Board =
+  lazy val finalizeAfter: Board =
     val board = after.variant.finalizeBoard(
       after updateHistory { h1 =>
         val h2 = h1.copy(

--- a/src/main/scala/Move.scala
+++ b/src/main/scala/Move.scala
@@ -2,6 +2,7 @@ package chess
 
 import chess.format.Uci
 import cats.syntax.all.*
+import chess.format.pgn.SanStr
 
 case class Move(
     piece: Piece,
@@ -15,14 +16,10 @@ case class Move(
     enpassant: Boolean,
     metrics: MoveMetrics = MoveMetrics.empty
 ):
-  inline def before = situationBefore.board
 
+  inline def before       = situationBefore.board
   lazy val situationAfter = Situation(finalizeAfter, !piece.color)
-  lazy val san            = format.pgn.Dumper(this)
-
-  inline def withHistory(inline h: History) = copy(after = after withHistory h)
-
-  val isWhiteTurn: Boolean = piece.color.white
+  lazy val san: SanStr    = format.pgn.Dumper(this)
 
   // TODO rethink about how handle castling
   // it's quite messy and error prone now
@@ -107,7 +104,10 @@ case class Move(
       copy(dest = rookOrig)
     }
 
-  inline def color = piece.color
+  val isWhiteTurn: Boolean = piece.color.white
+  inline def color         = piece.color
+
+  inline def withHistory(inline h: History) = copy(after = after withHistory h)
 
   def withPromotion(op: Option[PromotableRole]): Option[Move] =
     op.fold(this.some)(withPromotion)

--- a/src/main/scala/MoveOrDrop.scala
+++ b/src/main/scala/MoveOrDrop.scala
@@ -2,7 +2,6 @@ package chess
 
 import chess.format.Uci
 import chess.format.pgn.SanStr
-import chess.format.pgn.Dumper
 
 type MoveOrDrop = Move | Drop
 
@@ -46,8 +45,8 @@ object MoveOrDrop:
 
     inline def toSanStr: SanStr =
       md match
-        case m: Move => Dumper(m.situationBefore, m, m.situationAfter)
-        case d: Drop => Dumper(d, d.situationAfter)
+        case m: Move => m.san
+        case d: Drop => d.san
 
     inline def applyGame(game: Game): Game =
       md match


### PR DESCRIPTION
Have this idea, while reading: https://github.com/lichess-org/lila-ws/blob/master/src/main/scala/Chess.scala#L22-L25

In that function, `game.sans.lastOption` check  is unnecessary, because we we have the move, that is the evidence of `game.sans.last` cannot be `None`. But we have to do that check anyway, because the type system doesn't know `game.sans.last` is non empty.

This pr is to solved this problem, by adding `san` as a `lazy val` for both `Move` and `Drop`, so that we can access `san` whenever we have `MoveOrDrop`, without asking the `game.sans`. And also avoid re-computation of `san` when possible.