### PR TITLE
Fix deadlock because of lazy vals

### DIFF
--- a/src/main/scala/Drop.scala
+++ b/src/main/scala/Drop.scala
@@ -12,9 +12,9 @@ case class Drop(
     metrics: MoveMetrics = MoveMetrics.empty
 ):
 
-  inline def before       = situationBefore.board
-  lazy val situationAfter = Situation(finalizeAfter, !piece.color)
-  lazy val san: SanStr    = format.pgn.Dumper(this)
+  inline def before    = situationBefore.board
+  def situationAfter   = Situation(finalizeAfter, !piece.color)
+  lazy val san: SanStr = format.pgn.Dumper(this)
 
   lazy val finalizeAfter: Board =
     val board = after.variant.finalizeBoard(

--- a/src/main/scala/Move.scala
+++ b/src/main/scala/Move.scala
@@ -17,9 +17,9 @@ case class Move(
     metrics: MoveMetrics = MoveMetrics.empty
 ):
 
-  inline def before       = situationBefore.board
-  lazy val situationAfter = Situation(finalizeAfter, !piece.color)
-  lazy val san: SanStr    = format.pgn.Dumper(this)
+  inline def before    = situationBefore.board
+  def situationAfter   = Situation(finalizeAfter, !piece.color)
+  lazy val san: SanStr = format.pgn.Dumper(this)
 
   // TODO rethink about how handle castling
   // it's quite messy and error prone now


### PR DESCRIPTION
In some highly concurrent situation, lazy vals introduced in #466 causes deadlocks: https://github.com/lenguyenthanh/scalachess-tests/actions/runs/5766743713/job/15704620174

I still don't know the root cause of it, but this is fixed it (tested locally).