### PR TITLE
Traverse sans only once in gameMoveWhileValid

### DIFF
--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -46,7 +46,7 @@ object Replay:
         )
       )
 
-  def gameMoveWhileValid(
+  def gameMoveWhileValidReverse(
       sans: Seq[SanStr],
       initialFen: Fen.Epd,
       variant: Variant
@@ -63,9 +63,17 @@ object Replay:
                 .map: move =>
                   val newGame = move.applyGame(head)
                   (newGame, (newGame, Uci.WithSan(move.toUci, str)) :: games)
-            .leftMap(err => (init, games.reverse, err.some))
-      .map(gs => (init, gs._2.reverse, none))
+            .leftMap(err => (init, games, err.some))
+      .map(gs => (init, gs._2, none))
       .merge
+
+  def gameMoveWhileValid(
+      sans: Seq[SanStr],
+      initialFen: Fen.Epd,
+      variant: Variant
+  ): (Game, List[(Game, Uci.WithSan)], Option[ErrorStr]) =
+    gameMoveWhileValidReverse(sans, initialFen, variant) match
+      case (game, gs, err) => (game, gs.reverse, err)
 
   private def computeSituations[M](
       sit: Situation,

--- a/src/main/scala/Replay.scala
+++ b/src/main/scala/Replay.scala
@@ -54,16 +54,17 @@ object Replay:
     val init       = makeGame(variant, initialFen.some)
     val emptyGames = List.empty[(Game, Uci.WithSan)]
     sans
-      .foldM(emptyGames):
-        case (games, str) =>
+      .foldM((init, emptyGames)):
+        case ((head, games), str) =>
           Parser
             .sanOnly(str)
             .flatMap: san =>
-              val game = games.headOption.fold(init)(_._1)
-              san(game.situation)
-                .map(m => (m.applyGame(game), Uci.WithSan(m.toUci, str)) :: games)
+              san(head.situation)
+                .map: move =>
+                  val newGame = move.applyGame(head)
+                  (newGame, (newGame, Uci.WithSan(move.toUci, str)) :: games)
             .leftMap(err => (init, games.reverse, err.some))
-      .map(gs => (init, gs.reverse, none))
+      .map(gs => (init, gs._2.reverse, none))
       .merge
 
   private def computeSituations[M](


### PR DESCRIPTION
- Fix reversed order when error happen
- Add gameMoveWhileValidReverse because in some case we need
games in reverse order, for example: https://github.com/lichess-org/lila/blob/27f1db88d269c17a04ccdbdfa67ed9cda6bd4514/modules/study/src/main/ServerEval.scala#L147
- This is a bit slower than the previous implementation but I guess only in micro benchmark settings. The new implementation looks nicer and can short circuit when error happen.