### PR TITLE
Fix small test conversion

### DIFF
--- a/src/main/scala/format/Fen.scala
+++ b/src/main/scala/format/Fen.scala
@@ -92,7 +92,7 @@ object SmallFen extends OpaqueString[SmallFen]:
       val (board, error)     = Fen.makeBoardWithCrazyPromoted(e, chess.variant.Standard)
       val boardStr           = Fen.writeBoard(board)
       val boardSize          = boardStr.value.count(_ != '/')
-      val isBlackTurn        = e.lift(boardSize).exists(_ == 'b')
+      val isBlackTurn        = e.lift(boardSize).exists(_ == 'b') && !e.lift(boardSize + 1).exists(_.isDigit)
       val turnSize           = if isBlackTurn then 1 else 0
       val castlingStr        = e.drop(boardSize + turnSize).takeWhile(Set('K', 'Q', 'k', 'q').contains)
       val enpassantStr       = e.drop(boardSize + turnSize + castlingStr.size)
@@ -108,5 +108,6 @@ object SmallFen extends OpaqueString[SmallFen]:
     if variant == chess.variant.ThreeCheck
     then fen.value.split(' ').lift(6).foldLeft(base)(_ + _)
     else base
+
   def validate(variant: Variant, fen: Fen.Epd): Option[SmallFen] =
     Fen.read(variant, fen).exists(_ playable false) option make(variant, fen.simple)

--- a/test-kit/src/test/scala/format/SmallFenTest.scala
+++ b/test-kit/src/test/scala/format/SmallFenTest.scala
@@ -13,16 +13,27 @@ class SmallFenTest extends ChessTest:
       SmallFen.make(Standard, Fen.Simple("rnbqkb1r/ppp1pppp/3p4/3nP3/3P4/5N2/PPP2PPP/RNBQKB1R b KQkq -")),
       SmallFen("rnbqkb1rppp1pppp3p43nP33P45N2PPP2PPPRNBQKB1RbKQkq")
     )
+
+  test("standard, skip w, b6 en passant"):
+    assertEquals(
+      SmallFen
+        .make(Standard, Fen.Simple("8/8/p1k2nB1/Pp1np3/1PK4P/8/3B4/8 w - b6"))
+        .garbageInefficientReadBackIntoFen,
+      SimpleFen("8/8/p1k2nB1/Pp1np3/1PK4P/8/3B4/8 w - b6")
+    )
+
   test("make standard correct, skip w"):
     assertEquals(
       SmallFen.make(Standard, Fen.Simple("rnbqkb1r/ppp1pppp/3p4/3nP3/3P4/5N2/PPP2PPP/RNBQKB1R w KQkq -")),
       SmallFen("rnbqkb1rppp1pppp3p43nP33P45N2PPP2PPPRNBQKB1RKQkq")
     )
+
   test("make standard correct, non-initial castling"):
     assertEquals(
       SmallFen.make(Standard, Fen.Simple("rnbqkb1r/ppp1pppp/3p4/3nP3/3P4/5N2/PPP2PPP/RNBQKB1R w Qq -")),
       SmallFen("rnbqkb1rppp1pppp3p43nP33P45N2PPP2PPPRNBQKB1RQq")
     )
+
   test("make standard correct, en passant"):
     assertEquals(
       SmallFen


### PR DESCRIPTION
This happen when in White's turn, and there is a enpassant on b6.
Before this fix, it is mistaken the b from b6 as Black's turn. So,
the fix is make sure that only set black turn if there is no number
after character b.