### PR TITLE
Fix IndexOutOfBound when hashing Crazyhouse variant

### DIFF
--- a/src/main/scala/Hash.scala
+++ b/src/main/scala/Hash.scala
@@ -77,8 +77,9 @@ object Hash:
     def crazyPocketMask(role: Role, colorshift: Int, count: Int): Option[Long] =
       // There should be no kings and at most 16 pieces of any given type
       // in a pocket.
-      Option.when(0 < count && count <= 16 && role != King):
-        table.crazyPocketMasks(16 * roleIndex(role) + count + colorshift)
+      val index = 16 * roleIndex(role) + count + colorshift
+      Option.when(0 < count && count <= 16 && role != King && index < table.crazyPocketMasks.length):
+        table.crazyPocketMasks(index)
 
     import situation.board
     val hturn = situation.color.fold(table.whiteTurnMask, 0L)

--- a/test-kit/src/test/scala/CrazyhouseVariantTest.scala
+++ b/test-kit/src/test/scala/CrazyhouseVariantTest.scala
@@ -259,6 +259,7 @@ class CrazyhouseVariantTest extends ChessTest:
       .playMoves(moves*)
       .assertRight: g =>
         assertNot(g.board.history.threefoldRepetition)
+
   test("autodraw: not draw when only kings left"):
     val fenPosition = EpdFen("k6K/8/8/8/8/8/8/8 w - - 0 25")
     val game        = fenToGame(fenPosition, Crazyhouse)
@@ -267,11 +268,12 @@ class CrazyhouseVariantTest extends ChessTest:
     assertNot(game.situation.opponentHasInsufficientMaterial)
 
   test("prod 50 games accumulate hash"):
-    val gameMoves = format.pgn.Fixtures.prod50crazyhouse.map { g =>
+    val gameMoves = format.pgn.Fixtures.prod50crazyhouse.map: g =>
       SanStr from g.split(' ').toList
-    }
+
     def runOne(moves: List[SanStr]) =
       Replay.gameMoveWhileValid(moves, format.Fen.initial, Crazyhouse)
+
     def hex(buf: Array[Byte]): String = buf.map("%02x" format _).mkString
     val g                             = gameMoves.map(runOne)
     assertNot(g.exists(_._3.nonEmpty))
@@ -362,5 +364,10 @@ class CrazyhouseVariantTest extends ChessTest:
       case DropTestCase(fen, drops) =>
         val game = fenToGame(fen, Crazyhouse)
         assertEquals(Crazyhouse.possibleDrops(game.situation).map(_.toSet), drops)
+
+  test("Index out of bounds when hashing pockets"):
+    val fenPosition = EpdFen("2q1k1nr/B3bbrb/8/8/8/8/3qN1RB/1Q2KB1R/RRRQQQQQQrrrqqq w Kk - 0 11")
+    val game        = fenToGame(fenPosition, Crazyhouse)
+    assert(game.apply(E1, D2).isRight)
 
 case class DropTestCase(fen: EpdFen, drops: Option[Set[Square]])

--- a/test-kit/src/test/scala/HashTest.scala
+++ b/test-kit/src/test/scala/HashTest.scala
@@ -175,3 +175,8 @@ class HashTest extends ChessTest:
       val h   = Hash(16)
       g.foreach(_._2.foreach(x => m16.update(PositionHash value h(x._1.situation))))
       assertEquals(hex(m16.digest), "21281304d25ccf9c1dfd640775800087")
+
+  test("Index out of bounds when hashing pockets"):
+    val fenPosition = EpdFen("2q1k1nr/B3bbrb/8/8/8/8/3qN1RB/1Q2KB1R/RRRQQQQQQrrrqqq w Kk - 0 11")
+    val game        = fenToGame(fenPosition, Crazyhouse)
+    assert(game.apply(E1, D2).isRight)


### PR DESCRIPTION
This only happen in custom positions when there 
are too much materials. The fix is return None when
IndexOutOfBound happen, this will increase the
risk of collusion but the positions are invalid
in this case anyway.


This is an effort to remove the try catch in lila-ws
https://github.com/lichess-org/lila-ws/blob/a3f2d9ab3ec573e07ff05eb1e7db38d93e27e2da/src/main/scala/Chess.scala#L26