### PR TITLE
Implement reasonably fast and compact BinaryFen

### DIFF
--- a/bench/src/main/scala/benchmarks/BinaryFenBench.scala
+++ b/bench/src/main/scala/benchmarks/BinaryFenBench.scala
@@ -21,43 +21,43 @@ class BinaryFenBench:
   // the unit of CPU work per iteration
   private val Work: Long = 10
 
+  private val binary = BinaryFen(
+    Array(
+      0xff.toByte,
+      0xff.toByte,
+      0x00.toByte,
+      0x00.toByte,
+      0x10.toByte,
+      0x00.toByte,
+      0xef.toByte,
+      0xff.toByte,
+      0x2d.toByte,
+      0x84.toByte,
+      0x4a.toByte,
+      0xd2.toByte,
+      0x00.toByte,
+      0x00.toByte,
+      0x00.toByte,
+      0x00.toByte,
+      0x11.toByte,
+      0x11.toByte,
+      0x11.toByte,
+      0x11.toByte,
+      0x3e.toByte,
+      0x95.toByte,
+      0x5f.toByte,
+      0xe3.toByte
+    )
+  )
+
   @Benchmark
   def read(bh: Blackhole) =
     Blackhole.consumeCPU(Work)
-    bh.consume(
-      BinaryFen.read(
-        BinaryFen(
-          Array(
-            0xff.toByte,
-            0xff.toByte,
-            0x00.toByte,
-            0x00.toByte,
-            0x10.toByte,
-            0x00.toByte,
-            0xef.toByte,
-            0xff.toByte,
-            0x2d.toByte,
-            0x84.toByte,
-            0x4a.toByte,
-            0xd2.toByte,
-            0x00.toByte,
-            0x00.toByte,
-            0x00.toByte,
-            0x00.toByte,
-            0x11.toByte,
-            0x11.toByte,
-            0x11.toByte,
-            0x11.toByte,
-            0x3e.toByte,
-            0x95.toByte,
-            0x5f.toByte,
-            0xe3.toByte
-          )
-        )
-      )
-    )
+    bh.consume(BinaryFen.read(binary))
+
+  private val situation = Situation.AndFullMoveNumber(Situation(Standard), FullMoveNumber(1))
 
   @Benchmark
   def write(bh: Blackhole) =
     Blackhole.consumeCPU(Work)
-    bh.consume(BinaryFen.write(Situation.AndFullMoveNumber(Situation(Standard), FullMoveNumber(1))))
+    bh.consume(BinaryFen.write(situation))

--- a/bench/src/main/scala/benchmarks/BinaryFenBench.scala
+++ b/bench/src/main/scala/benchmarks/BinaryFenBench.scala
@@ -1,0 +1,63 @@
+package benchmarks
+
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+import java.util.concurrent.TimeUnit
+
+import cats.syntax.all.*
+import chess.{ FullMoveNumber, Situation }
+import chess.format.BinaryFen
+import chess.variant.Standard
+
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Fork(value = 3)
+@Threads(value = 1)
+class BinaryFenBench:
+
+  // the unit of CPU work per iteration
+  private val Work: Long = 10
+
+  @Benchmark
+  def read(bh: Blackhole) =
+    Blackhole.consumeCPU(Work)
+    bh.consume(
+      BinaryFen.read(
+        BinaryFen(
+          Array(
+            0xff.toByte,
+            0xff.toByte,
+            0x00.toByte,
+            0x00.toByte,
+            0x10.toByte,
+            0x00.toByte,
+            0xef.toByte,
+            0xff.toByte,
+            0x2d.toByte,
+            0x84.toByte,
+            0x4a.toByte,
+            0xd2.toByte,
+            0x00.toByte,
+            0x00.toByte,
+            0x00.toByte,
+            0x00.toByte,
+            0x11.toByte,
+            0x11.toByte,
+            0x11.toByte,
+            0x11.toByte,
+            0x3e.toByte,
+            0x95.toByte,
+            0x5f.toByte,
+            0xe3.toByte
+          )
+        )
+      )
+    )
+
+  @Benchmark
+  def write(bh: Blackhole) =
+    Blackhole.consumeCPU(Work)
+    bh.consume(BinaryFen.write(Situation.AndFullMoveNumber(Situation(Standard), FullMoveNumber(1))))

--- a/src/main/scala/Rank.scala
+++ b/src/main/scala/Rank.scala
@@ -5,10 +5,10 @@ object Rank:
   extension (a: Rank)
     inline def value: Int = a
 
-    inline infix def >(inline o: Rank): Boolean  = a > o
-    inline infix def <(inline o: Rank): Boolean  = a < o
-    inline infix def >=(inline o: Rank): Boolean = a >= o
-    inline infix def <=(inline o: Rank): Boolean = a <= o
+    inline infix def >(inline o: Rank): Boolean  = value > o.value
+    inline infix def <(inline o: Rank): Boolean  = value < o.value
+    inline infix def >=(inline o: Rank): Boolean = value >= o.value
+    inline infix def <=(inline o: Rank): Boolean = value <= o.value
 
     inline def char: Char = (49 + a).toChar
   end extension

--- a/src/main/scala/Square.scala
+++ b/src/main/scala/Square.scala
@@ -44,11 +44,6 @@ object Square:
     inline def file: File = File.of(s)
     inline def rank: Rank = Rank.of(s)
 
-    inline def xor(inline other: Square): Square =
-      // this is guaranteed to stay in bounds, and for some operands a
-      // useful geometric transformation
-      s.value ^ other.value
-
     def asChar: Char =
       if s <= 25 then (97 + s).toChar      // a ...
       else if s <= 51 then (39 + s).toChar // A ...

--- a/src/main/scala/Square.scala
+++ b/src/main/scala/Square.scala
@@ -44,6 +44,11 @@ object Square:
     inline def file: File = File.of(s)
     inline def rank: Rank = Rank.of(s)
 
+    inline def xor(inline other: Square): Square =
+      // this is guaranteed to stay in bounds, and for some operands a
+      // useful geometric transformation
+      s.value ^ other.value
+
     def asChar: Char =
       if s <= 25 then (97 + s).toChar      // a ...
       else if s <= 51 then (39 + s).toChar // A ...

--- a/src/main/scala/bitboard/Bitboard.scala
+++ b/src/main/scala/bitboard/Bitboard.scala
@@ -104,7 +104,7 @@ object Bitboard:
 
     def isolateFirst: Bitboard = Bitboard(a & -a)
 
-    def isolateLast: Bitboard = last.map(_.bb).getOrElse(0L)
+    def isolateLast: Bitboard = last.fold(empty)(_.bl)
 
     inline def intersects(inline o: Long): Boolean =
       (a & o) != 0L

--- a/src/main/scala/bitboard/Bitboard.scala
+++ b/src/main/scala/bitboard/Bitboard.scala
@@ -229,9 +229,9 @@ object Bitboard:
       builder.result
 
     def iterator: Iterator[Square] = new Iterator[Square]:
-      private var b                 = a
-      override def hasNext: Boolean = b != 0L
-      override def next: Square =
+      private var b                        = a
+      override inline def hasNext: Boolean = b != 0L
+      override inline def next: Square =
         val result = b.lsb
         b &= (b - 1L)
         result

--- a/src/main/scala/bitboard/Bitboard.scala
+++ b/src/main/scala/bitboard/Bitboard.scala
@@ -102,6 +102,10 @@ object Bitboard:
     // remove the last/largest non empty square
     def removeLast: Bitboard = a & ~a.msb.bl
 
+    def isolateFirst: Bitboard = Bitboard(a & -a)
+
+    def isolateLast: Bitboard = last.map(_.bb).getOrElse(0)
+
     inline def intersects(inline o: Long): Boolean =
       (a & o) != 0L
 

--- a/src/main/scala/bitboard/Bitboard.scala
+++ b/src/main/scala/bitboard/Bitboard.scala
@@ -104,7 +104,7 @@ object Bitboard:
 
     def isolateFirst: Bitboard = Bitboard(a & -a)
 
-    def isolateLast: Bitboard = last.map(_.bb).getOrElse(0)
+    def isolateLast: Bitboard = last.map(_.bb).getOrElse(0L)
 
     inline def intersects(inline o: Long): Boolean =
       (a & o) != 0L

--- a/src/main/scala/bitboard/Bitboard.scala
+++ b/src/main/scala/bitboard/Bitboard.scala
@@ -232,7 +232,7 @@ object Bitboard:
         b &= (b - 1L)
       builder.result
 
-    def iterator: Iterator[Square] = new Iterator[Square]:
+    def iterator: Iterator[Square] = new:
       private var b                        = a
       override inline def hasNext: Boolean = b != 0L
       override inline def next: Square =

--- a/src/main/scala/bitboard/Bitboard.scala
+++ b/src/main/scala/bitboard/Bitboard.scala
@@ -228,6 +228,14 @@ object Bitboard:
         b &= (b - 1L)
       builder.result
 
+    def iterator: Iterator[Square] = new Iterator[Square]:
+      private var b                 = a
+      override def hasNext: Boolean = b != 0L
+      override def next: Square =
+        val result = b.lsb
+        b &= (b - 1L)
+        result
+
     // TODO: nice to have, faster.
     // but should only be used for debug
     // TODO: override toString?

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -11,21 +11,24 @@ object BinaryFen:
   extension (bf: BinaryFen)
     def read: Situation.AndFullMoveNumber =
       val reader = new Iterator[Byte]:
-        val inner                   = bf.iterator
-        inline def hasNext: Boolean = inner.hasNext
-        inline def next: Byte       = if hasNext then inner.next else 0.toByte
+        val inner                            = bf.iterator
+        override inline def hasNext: Boolean = inner.hasNext
+        override inline def next: Byte       = if hasNext then inner.next else 0.toByte
 
-      val occupied     = Bitboard(readLong(reader))
-      var pawns        = Bitboard.empty
-      var knights      = Bitboard.empty
-      var bishops      = Bitboard.empty
-      var rooks        = Bitboard.empty
-      var queens       = Bitboard.empty
-      var kings        = Bitboard.empty
-      var white        = Bitboard.empty
-      var black        = Bitboard.empty
-      var unmovedRooks = Bitboard.empty
-      var turn         = White
+      val occupied = Bitboard(readLong(reader))
+
+      var pawns   = Bitboard.empty
+      var knights = Bitboard.empty
+      var bishops = Bitboard.empty
+      var rooks   = Bitboard.empty
+      var queens  = Bitboard.empty
+      var kings   = Bitboard.empty
+      var white   = Bitboard.empty
+      var black   = Bitboard.empty
+
+      var turn                     = White
+      var unmovedRooks             = Bitboard.empty
+      var epMove: Option[Uci.Move] = None
 
       def unpackPiece(sq: Square, nibble: Int) =
         val bb = sq.bb
@@ -68,7 +71,9 @@ object BinaryFen:
             black |= bb
           case 12 =>
             pawns |= bb
-          // TODO: color, ep
+            epMove = Some(Uci.Move(sq.xor(Square.A3), sq))
+            if sq.rank.value < 4 then white |= bb
+            else black |= bb
           case 13 =>
             rooks |= bb
             white |= bb
@@ -140,6 +145,8 @@ object BinaryFen:
               kings = kings
             ),
             History(
+              lastMove = epMove,
+              checkCount = checkCount,
               unmovedRooks = UnmovedRooks(unmovedRooks),
               halfMoveClock = halfMoveClock
             ),

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -76,7 +76,7 @@ object BinaryFen:
             black |= bb
           case 12 =>
             pawns |= bb
-            epMove = Some(Uci.Move(sq.xor(Square.A3), sq))
+            epMove = Some(Uci.Move(Square.unsafe(sq.value ^ 0x10), sq))
             if sq.rank <= Rank.Fourth then white |= bb
             else black |= bb
           case 13 =>
@@ -176,8 +176,8 @@ object BinaryFen:
     val occupied = sit.board.occupied
     writeLong(builder, occupied.value)
 
-    val unmovedRooks                 = minimumUnmovedRooks(sit.board)
-    val pawnPushedTo: Option[Square] = sit.enPassantSquare.map(_.xor(Square.A2))
+    val unmovedRooks = minimumUnmovedRooks(sit.board)
+    val pawnPushedTo = sit.enPassantSquare.flatMap(_.prevRank(sit.color))
 
     def packPiece(sq: Square): Byte =
       sit.board(sq) match

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -231,7 +231,7 @@ object BinaryFen:
         writeNibbles(builder, pockets.white.bishop, pockets.black.bishop)
         writeNibbles(builder, pockets.white.rook, pockets.black.rook)
         writeNibbles(builder, pockets.white.queen, pockets.black.queen)
-        writeLong(builder, crazyData.promoted.value)
+        if crazyData.promoted.nonEmpty then writeLong(builder, crazyData.promoted.value)
 
     builder.result
 

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -218,7 +218,7 @@ object BinaryFen:
       case RacingKings   => 9
 
     if halfMoveClock > 0 || ply > 1 || brokenTurn || variantHeader != 0
-    then writeLeb128(builder, sit.history.halfMoveClock.value)
+    then writeLeb128(builder, halfMoveClock)
 
     if ply > 1 || brokenTurn || variantHeader != 0
     then writeLeb128(builder, ply)

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -9,6 +9,8 @@ import scala.collection.mutable.ArrayBuilder
 opaque type BinaryFen = Array[Byte]
 
 object BinaryFen:
+  def apply(value: Array[Byte]): BinaryFen = value
+
   extension (bf: BinaryFen)
     def value: Array[Byte] = bf
 

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -236,14 +236,18 @@ object BinaryFen:
     builder.result
 
   private def writeLong(builder: ArrayBuilder[Byte], v: Long) =
-    builder.addOne((v >>> 56).toByte)
-    builder.addOne((v >>> 48).toByte)
-    builder.addOne((v >>> 40).toByte)
-    builder.addOne((v >>> 32).toByte)
-    builder.addOne((v >>> 24).toByte)
-    builder.addOne((v >>> 16).toByte)
-    builder.addOne((v >>> 8).toByte)
-    builder.addOne(v.toByte)
+    builder.addAll(
+      Array(
+        (v >>> 56).toByte,
+        (v >>> 48).toByte,
+        (v >>> 40).toByte,
+        (v >>> 32).toByte,
+        (v >>> 24).toByte,
+        (v >>> 16).toByte,
+        (v >>> 8).toByte,
+        v.toByte
+      )
+    )
 
   private def readLong(reader: Iterator[Byte]): Long =
     ((reader.next & 0xffL) << 56) |

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -103,13 +103,16 @@ object BinaryFen:
       val halfMoveClock = HalfMoveClock(readLeb128(reader))
       var ply           = Ply(readLeb128(reader))
       val variant = reader.next match
-        case 1 => ThreeCheck
-        case 2 => Antichess
-        case 3 => Atomic
-        case 4 => Horde
-        case 5 => RacingKings
-        case 6 => Crazyhouse
-        case 7 => KingOfTheHill
+        case 0 => Standard
+        case 1 => Crazyhouse
+        case 2 => Chess960
+        case 3 => FromPosition
+        case 4 => KingOfTheHill
+        case 5 => ThreeCheck
+        case 6 => Antichess
+        case 7 => Atomic
+        case 8 => Horde
+        case 9 => RacingKings
         case _ => Standard
 
       if ply.turn.black then turn = Black
@@ -203,14 +206,16 @@ object BinaryFen:
     val ply           = input.fullMoveNumber.ply(sit.color).value
     val brokenTurn    = sit.color.black && sit.board(Black, King).isEmpty
     val variantHeader = sit.variant match
-      case Standard | Chess960 | FromPosition => 0
-      case ThreeCheck                         => 1
-      case Antichess                          => 2
-      case Atomic                             => 3
-      case Horde                              => 4
-      case RacingKings                        => 5
-      case Crazyhouse                         => 6
-      case KingOfTheHill                      => 7
+      case Standard      => 0
+      case Crazyhouse    => 1
+      case Chess960      => 2
+      case FromPosition  => 3
+      case KingOfTheHill => 4
+      case ThreeCheck    => 5
+      case Antichess     => 6
+      case Atomic        => 7
+      case Horde         => 8
+      case RacingKings   => 9
 
     if halfMoveClock > 0 || ply > 1 || brokenTurn || variantHeader != 0
     then writeLeb128(builder, sit.history.halfMoveClock.value)

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -77,7 +77,7 @@ object BinaryFen:
           case 12 =>
             pawns |= bb
             epMove = Some(Uci.Move(sq.xor(Square.A3), sq))
-            if sq.rank.value < 4 then white |= bb
+            if sq.rank <= Rank.Fourth then white |= bb
             else black |= bb
           case 13 =>
             rooks |= bb

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -1,0 +1,102 @@
+package chess
+package format
+
+import scala.collection.mutable.ArrayBuilder
+
+opaque type BinaryFen = Array[Byte]
+
+object BinaryFen:
+  extension (bf: BinaryFen)
+    def read: Situation =
+      val fused = new Iterator[Byte]:
+        val inner                   = bf.iterator
+        inline def hasNext: Boolean = inner.hasNext
+        inline def next: Byte       = if hasNext then inner.next else 0.toByte
+      ???
+
+  def write(input: Situation.AndFullMoveNumber): BinaryFen =
+    val builder = ArrayBuilder.ofByte()
+
+    val sit      = input.situation
+    val occupied = sit.board.occupied
+    addLong(builder, occupied.value)
+
+    val pawnPushedTo: Option[Square] = sit.enPassantSquare.map(_.xor(Square.A2))
+
+    def compressPiece(sq: Square): Byte =
+      sit.board(sq) match
+        case Some(Piece(_, Pawn)) if pawnPushedTo.contains(sq) => 12
+        case Some(Piece(White, Pawn))                          => 0
+        case Some(Piece(Black, Pawn))                          => 1
+        case Some(Piece(White, Knight))                        => 2
+        case Some(Piece(Black, Knight))                        => 3
+        case Some(Piece(White, Bishop))                        => 4
+        case Some(Piece(Black, Bishop))                        => 5
+        case Some(Piece(White, Rook))  => if sit.history.unmovedRooks.contains(sq) then 13 else 6
+        case Some(Piece(Black, Rook))  => if sit.history.unmovedRooks.contains(sq) then 14 else 7
+        case Some(Piece(White, Queen)) => 8
+        case Some(Piece(Black, Queen)) => 9
+        case Some(Piece(White, King))  => 10
+        case Some(Piece(Black, King))  => if sit.color.white then 11 else 15
+        case None                      => 0 // unreachable
+
+    val it = occupied.iterator
+    while it.hasNext
+    do addNibbles(builder, compressPiece(it.next), if it.hasNext then compressPiece(it.next) else 0)
+
+    val halfMoves = sit.history.halfMoveClock.value
+
+    val ply        = input.fullMoveNumber.ply(sit.color).value
+    val brokenTurn = sit.color.black && sit.board(Black, King).isEmpty
+    val variantHeader = sit.variant match
+      case variant.Standard | variant.Chess960 | variant.FromPosition => 0
+      case variant.ThreeCheck                                         => 1
+      case variant.Antichess                                          => 2
+      case variant.Atomic                                             => 3
+      case variant.Horde                                              => 4
+      case variant.RacingKings                                        => 5
+      case variant.Crazyhouse                                         => 6
+
+    if halfMoves > 0 || ply > 1 || brokenTurn || variantHeader != 0
+    then addLeb128(builder, sit.history.halfMoveClock.value)
+
+    if ply > 1 || brokenTurn || variantHeader != 0
+    then addLeb128(builder, ply)
+
+    if variantHeader != 0
+    then
+      builder.addOne(variantHeader.toByte)
+      if sit.variant.threeCheck then
+        addNibbles(builder, sit.history.checkCount.white, sit.history.checkCount.black)
+      else if sit.variant.crazyhouse then
+        val crazyData = sit.board.crazyData.getOrElse(variant.Crazyhouse.Data.init)
+        addLong(builder, crazyData.promoted.value)
+        val pockets = crazyData.pockets
+        addNibbles(builder, pockets.white.pawn, pockets.black.pawn)
+        addNibbles(builder, pockets.white.knight, pockets.black.knight)
+        addNibbles(builder, pockets.white.bishop, pockets.black.bishop)
+        addNibbles(builder, pockets.white.rook, pockets.black.rook)
+        addNibbles(builder, pockets.white.queen, pockets.black.queen)
+
+    builder.result
+
+  private def addLong(builder: ArrayBuilder[Byte], v: Long) =
+    builder.addOne((v >>> 56).toByte)
+    builder.addOne((v >>> 48).toByte)
+    builder.addOne((v >>> 40).toByte)
+    builder.addOne((v >>> 32).toByte)
+    builder.addOne((v >>> 24).toByte)
+    builder.addOne((v >>> 16).toByte)
+    builder.addOne((v >>> 8).toByte)
+    builder.addOne(v.toByte)
+
+  private def addLeb128(builder: ArrayBuilder[Byte], v: Int) =
+    var n = v
+    while n > 127
+    do
+      builder.addOne((n | 128).toByte)
+      n = n >>> 7
+    builder.addOne(n.toByte)
+
+  private def addNibbles(builder: ArrayBuilder[Byte], lo: Int, hi: Int) =
+    builder.addOne((lo | (hi << 4)).toByte)

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -1,9 +1,10 @@
 package chess
 package format
 
-import scala.collection.mutable.ArrayBuilder
-import chess.variant.*
 import chess.bitboard.{ Bitboard, Board as BBoard }
+import chess.variant.*
+
+import scala.collection.mutable.ArrayBuilder
 
 opaque type BinaryFen = Array[Byte]
 

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -2,17 +2,100 @@ package chess
 package format
 
 import scala.collection.mutable.ArrayBuilder
+import chess.variant.*
+import chess.bitboard.{ Bitboard, Board as BBoard }
 
 opaque type BinaryFen = Array[Byte]
 
 object BinaryFen:
   extension (bf: BinaryFen)
-    def read: Situation =
-      val fused = new Iterator[Byte]:
+    def read: Situation.AndFullMoveNumber =
+      val reader = new Iterator[Byte]:
         val inner                   = bf.iterator
         inline def hasNext: Boolean = inner.hasNext
         inline def next: Byte       = if hasNext then inner.next else 0.toByte
-      ???
+
+      val occupied     = Bitboard(readLong(reader))
+      var pawns        = Bitboard.empty
+      var knights      = Bitboard.empty
+      var bishops      = Bitboard.empty
+      var rooks        = Bitboard.empty
+      var queens       = Bitboard.empty
+      var kings        = Bitboard.empty
+      var white        = Bitboard.empty
+      var black        = Bitboard.empty
+      var unmovedRooks = Bitboard.empty
+      var turn         = White
+
+      def unpackPiece(sq: Square, nibble: Int) = ???
+
+      val it = occupied.iterator
+      while it.hasNext
+      do
+        val (lo, hi) = readNibbles(reader)
+        unpackPiece(it.next, lo)
+        if it.hasNext then unpackPiece(it.next, hi)
+
+      val halfMoves     = readLeb128(reader)
+      var ply           = Ply(readLeb128(reader))
+      val variantHeader = reader.next
+
+      if ply.turn.black then turn = Black
+
+      val variant = variantHeader match
+        case 1 => ThreeCheck
+        case 2 => Antichess
+        case 3 => Atomic
+        case 4 => Horde
+        case 5 => RacingKings
+        case 6 => Crazyhouse
+        case _ => Standard
+
+      val checkCount = if variant.threeCheck then
+        val (lo, hi) = readNibbles(reader)
+        CheckCount(lo, hi)
+      else CheckCount()
+
+      val crazyData = if variant.crazyhouse then
+        val promoted = readLong(reader)
+        val (wp, bp) = readNibbles(reader)
+        val (wn, bn) = readNibbles(reader)
+        val (wb, bb) = readNibbles(reader)
+        val (wr, br) = readNibbles(reader)
+        val (wq, bq) = readNibbles(reader)
+        Some(
+          Crazyhouse.Data(
+            ByColor(
+              white = Crazyhouse.Pocket(pawn = wp, knight = wn, bishop = wb, rook = wr, queen = wq),
+              black = Crazyhouse.Pocket(pawn = bp, knight = bn, bishop = bb, rook = br, queen = bq)
+            ),
+            Bitboard(promoted)
+          )
+        )
+      else None
+
+      Situation.AndFullMoveNumber(
+        Situation(
+          Board(
+            BBoard(
+              occupied = occupied,
+              white = white,
+              black = black,
+              pawns = pawns,
+              knights = knights,
+              bishops = bishops,
+              rooks = rooks,
+              queens = queens,
+              kings = kings
+            ),
+            History(unmovedRooks = UnmovedRooks(unmovedRooks)),
+            variant,
+            crazyData
+          ),
+          color = turn
+        ),
+        ply.fullMoveNumber
+      )
 
   def write(input: Situation.AndFullMoveNumber): BinaryFen =
     val builder = ArrayBuilder.ofByte()
@@ -23,7 +106,7 @@ object BinaryFen:
 
     val pawnPushedTo: Option[Square] = sit.enPassantSquare.map(_.xor(Square.A2))
 
-    def compressPiece(sq: Square): Byte =
+    def packPiece(sq: Square): Byte =
       sit.board(sq) match
         case Some(Piece(_, Pawn)) if pawnPushedTo.contains(sq) => 12
         case Some(Piece(White, Pawn))                          => 0
@@ -42,20 +125,19 @@ object BinaryFen:
 
     val it = occupied.iterator
     while it.hasNext
-    do addNibbles(builder, compressPiece(it.next), if it.hasNext then compressPiece(it.next) else 0)
+    do addNibbles(builder, packPiece(it.next), if it.hasNext then packPiece(it.next) else 0)
 
-    val halfMoves = sit.history.halfMoveClock.value
-
+    val halfMoves  = sit.history.halfMoveClock.value
     val ply        = input.fullMoveNumber.ply(sit.color).value
     val brokenTurn = sit.color.black && sit.board(Black, King).isEmpty
     val variantHeader = sit.variant match
-      case variant.Standard | variant.Chess960 | variant.FromPosition => 0
-      case variant.ThreeCheck                                         => 1
-      case variant.Antichess                                          => 2
-      case variant.Atomic                                             => 3
-      case variant.Horde                                              => 4
-      case variant.RacingKings                                        => 5
-      case variant.Crazyhouse                                         => 6
+      case Standard | Chess960 | FromPosition => 0
+      case ThreeCheck                         => 1
+      case Antichess                          => 2
+      case Atomic                             => 3
+      case Horde                              => 4
+      case RacingKings                        => 5
+      case Crazyhouse                         => 6
 
     if halfMoves > 0 || ply > 1 || brokenTurn || variantHeader != 0
     then addLeb128(builder, sit.history.halfMoveClock.value)
@@ -69,7 +151,7 @@ object BinaryFen:
       if sit.variant.threeCheck then
         addNibbles(builder, sit.history.checkCount.white, sit.history.checkCount.black)
       else if sit.variant.crazyhouse then
-        val crazyData = sit.board.crazyData.getOrElse(variant.Crazyhouse.Data.init)
+        val crazyData = sit.board.crazyData.getOrElse(Crazyhouse.Data.init)
         addLong(builder, crazyData.promoted.value)
         val pockets = crazyData.pockets
         addNibbles(builder, pockets.white.pawn, pockets.black.pawn)
@@ -90,6 +172,16 @@ object BinaryFen:
     builder.addOne((v >>> 8).toByte)
     builder.addOne(v.toByte)
 
+  private def readLong(reader: Iterator[Byte]): Long =
+    (reader.next.toLong << 56) |
+      (reader.next.toLong << 48) |
+      (reader.next.toLong << 40) |
+      (reader.next.toLong << 32) |
+      (reader.next.toLong << 24) |
+      (reader.next.toLong << 16) |
+      (reader.next.toLong << 8) |
+      reader.next.toLong
+
   private def addLeb128(builder: ArrayBuilder[Byte], v: Int) =
     var n = v
     while n > 127
@@ -98,5 +190,20 @@ object BinaryFen:
       n = n >>> 7
     builder.addOne(n.toByte)
 
+  private def readLeb128(reader: Iterator[Byte]): Int =
+    var n     = 0
+    var shift = 0
+    while
+      val b = reader.next
+      n |= (b & 127) << shift
+      shift += 7
+      (b & 128) != 0
+    do ()
+    n
+
   private def addNibbles(builder: ArrayBuilder[Byte], lo: Int, hi: Int) =
     builder.addOne((lo | (hi << 4)).toByte)
+
+  private def readNibbles(reader: Iterator[Byte]): (Int, Int) =
+    val b = reader.next
+    ((b & 0xf), (b >> 4))

--- a/src/main/scala/format/BinaryFen.scala
+++ b/src/main/scala/format/BinaryFen.scala
@@ -107,6 +107,7 @@ object BinaryFen:
         case 4 => Horde
         case 5 => RacingKings
         case 6 => Crazyhouse
+        case 7 => KingOfTheHill
         case _ => Standard
 
       if ply.turn.black then turn = Black
@@ -207,6 +208,7 @@ object BinaryFen:
       case Horde                              => 4
       case RacingKings                        => 5
       case Crazyhouse                         => 6
+      case KingOfTheHill                      => 7
 
     if halfMoveClock > 0 || ply > 1 || brokenTurn || variantHeader != 0
     then writeLeb128(builder, sit.history.halfMoveClock.value)

--- a/src/main/scala/format/FenWriter.scala
+++ b/src/main/scala/format/FenWriter.scala
@@ -59,7 +59,7 @@ trait FenWriter:
             if piece.role != Pawn && board.crazyData.exists(_.promoted.contains(Square(x, y))) then
               fen.append('~')
       if empty > 0 then fen.append(empty)
-      if y.value > Rank.First.value then fen.append('/')
+      if y > Rank.First then fen.append('/')
     BoardFen(fen.toString)
 
   def writeBoardAndColor(situation: Situation): BoardAndColorFen =

--- a/test-kit/src/test/scala/format/BinaryFenTest.scala
+++ b/test-kit/src/test/scala/format/BinaryFenTest.scala
@@ -48,6 +48,12 @@ class BinaryFenTest extends ChessTest:
       Crazyhouse,
       EpdFen("1r3Q1n/p1kp3p/1p2ppq1/2p2b2/8/3P2P1/PPP1PPBP/R4RK1/NRpnnbb w - - 2 28")
     )
+    assertRoundtrip(Crazyhouse, EpdFen("b2nkbnQ~/p1pppp1p/pP1q2p1/r7/8/R5PR/P1PP1P1P/1NBQ1BNK/R w - - 1 2"))
+    assertRoundtrip(Crazyhouse, EpdFen("8/8/8/8/8/8/8/8/ w - - 0 1"))
+    assertRoundtrip(
+      Crazyhouse,
+      EpdFen("r~n~b~q~kb~n~r~/pppppppp/8/8/8/8/PPPPPPPP/RN~BQ~KB~NR/ w KQkq - 0 1")
+    )
 
   test("fen fixtures"):
     for fen <- FenFixtures.fens do assertRoundtrip(Standard, fen)

--- a/test-kit/src/test/scala/format/BinaryFenTest.scala
+++ b/test-kit/src/test/scala/format/BinaryFenTest.scala
@@ -35,6 +35,10 @@ class BinaryFenTest extends ChessTest:
     )
 
     assertRoundtrip(Antichess, EpdFen("8/2p1p2p/2Q1N2B/8/p7/N7/PPP1P1PP/R4B1R b - - 0 13"))
+    assertRoundtrip(Antichess, EpdFen("8/p6p/4p3/1P4P1/Pp4p1/3P4/7P/8 b - a3 0 1"))
+    assertRoundtrip(Antichess, EpdFen("8/p6p/4p3/1P4P1/1p4pP/3P4/P7/8 b - h3 0 1"))
+    assertRoundtrip(Antichess, EpdFen("8/7p/4p3/pP4P1/1p1P2p1/8/P6P/8 w - a6 0 2"))
+    assertRoundtrip(Antichess, EpdFen("8/p7/4p3/1P4Pp/1p1P2p1/8/P6P/8 w - h6 0 2"))
 
     assertRoundtrip(Atomic, EpdFen("rnbq3r/ppp1p1pp/5p2/3p4/8/8/PPPPPPPP/RNBQKB1R b KQ - 0 4"))
     assertRoundtrip(Atomic, EpdFen("8/6pp/2p2p1n/3p4/4P3/B6P/3P1PP1/1r2K2R b K - 0 17"))

--- a/test-kit/src/test/scala/format/BinaryFenTest.scala
+++ b/test-kit/src/test/scala/format/BinaryFenTest.scala
@@ -1,15 +1,59 @@
 package chess
 package format
 
-import chess.variant.{ Standard, Variant }
+import chess.bitboard.FenFixtures
+import chess.variant.*
 
 class BinaryFenTest extends ChessTest:
-  test("roundtrip"):
-    assertRoundtrip(Standard, "8/8/8/8/8/8/8/8 w - - 0 1")
-    assertRoundtrip(Standard, "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1")
+  test("handpicked roundtrip"):
+    assertRoundtrip(Standard, EpdFen("8/8/8/8/8/8/8/8 w - - 0 1"))
+    assertRoundtrip(Standard, EpdFen("8/8/8/8/8/8/8/8 b - - 0 1"))
+    assertRoundtrip(Standard, EpdFen("8/8/8/8/8/8/8/8 w - - 0 2"))
+    assertRoundtrip(Standard, EpdFen("8/8/8/8/8/8/8/8 b - - 0 2"))
+    assertRoundtrip(Standard, EpdFen("8/8/8/8/8/8/8/8 b - - 100 432"))
+    assertRoundtrip(Standard, EpdFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"))
+    assertRoundtrip(Standard, EpdFen("4nrk1/1pp3pp/p4p2/4P3/2BB1n2/8/PP3P1P/2K3R1 b - - 1 25"))
+    assertRoundtrip(Standard, EpdFen("5k2/6p1/8/1Pp5/6P1/8/8/3K4 w - c6 0 1"))
+    assertRoundtrip(Standard, EpdFen("4k3/8/8/8/3pP3/8/6N1/7K b - e3 0 1"))
+    assertRoundtrip(Standard, EpdFen("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"))
+    assertRoundtrip(Standard, EpdFen("r1k1r2q/p1ppp1pp/8/8/8/8/P1PPP1PP/R1K1R2Q w KQkq - 0 1"))
+    assertRoundtrip(Standard, EpdFen("r1k2r1q/p1ppp1pp/8/8/8/8/P1PPP1PP/R1K2R1Q w KQkq - 0 1"))
+    assertRoundtrip(Standard, EpdFen("8/8/8/4B2b/6nN/8/5P2/2R1K2k w Q - 1 1"))
+    assertRoundtrip(Standard, EpdFen("2r5/8/8/8/8/8/6PP/k2KR3 w K - 0 2"))
+    assertRoundtrip(Standard, EpdFen("4r3/3k4/8/8/8/8/6PP/qR1K1R2 w KQ - 2 1"))
+    assertRoundtrip(Standard, EpdFen("4rrk1/pbbp2p1/1ppnp3/3n1pqp/3N1PQP/1PPNP3/PBBP2P1/4RRK1 w Ff - 0 3"))
+    assertRoundtrip(Standard, EpdFen("8/8/8/1k6/3Pp3/8/8/4KQ2 b - d3 3 1"))
+    assertRoundtrip(Standard, EpdFen("r2r3k/p7/3p4/8/8/P6P/8/R3K2R b KQq - 0 4"))
 
-  private def assertRoundtrip(variant: Variant, fen: String) =
-    val situation    = Fen.readWithMoveNumber(variant, EpdFen(fen)).get
+    assertRoundtrip(Chess960, EpdFen("rn2k1r1/ppp1pp1p/3p2p1/5bn1/P7/2N2B2/1PPPPP2/2BNK1RR w Gkq - 4 11"))
+
+    assertRoundtrip(
+      Horde,
+      EpdFen("rn1qkb1r/3bn1p1/2p3P1/pPP2P2/P1PPP1P1/P1PP1PPP/PPPPPPPP/PPPPPPPP w kq a6 0 12")
+    )
+
+    assertRoundtrip(Antichess, EpdFen("8/2p1p2p/2Q1N2B/8/p7/N7/PPP1P1PP/R4B1R b - - 0 13"))
+
+    assertRoundtrip(Atomic, EpdFen("rnbq3r/ppp1p1pp/5p2/3p4/8/8/PPPPPPPP/RNBQKB1R b KQ - 0 4"))
+    assertRoundtrip(Atomic, EpdFen("8/6pp/2p2p1n/3p4/4P3/B6P/3P1PP1/1r2K2R b K - 0 17"))
+
+    assertRoundtrip(RacingKings, EpdFen("8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"))
+    assertRoundtrip(RacingKings, EpdFen("8/8/8/8/8/6K1/krbnNBR1/qrbnNBRQ b - - 1 1"))
+
+    assertRoundtrip(KingOfTheHill, EpdFen("rnbq1bnr/ppp2ppp/3k4/4p2Q/3PK3/8/PPP2PPP/RNB2BNR b - - 0 7"))
+
+    assertRoundtrip(ThreeCheck, EpdFen("1r3rk1/pbp1N1pp/3p1q2/1p2bp2/7P/2PBB1P1/PP3Q1R/R5K1 b - - 3 21 +2+1"))
+
+    assertRoundtrip(
+      Crazyhouse,
+      EpdFen("1r3Q1n/p1kp3p/1p2ppq1/2p2b2/8/3P2P1/PPP1PPBP/R4RK1/NRpnnbb w - - 2 28")
+    )
+
+  test("fen fixtures"):
+    for fen <- FenFixtures.fens do assertRoundtrip(Standard, fen)
+
+  private def assertRoundtrip(variant: Variant, fen: EpdFen) =
+    val situation    = Fen.readWithMoveNumber(variant, fen).get
     val bytes        = BinaryFen.write(situation)
     val roundtripped = BinaryFen.read(bytes)
     assertEquals(Fen.write(roundtripped), fen)

--- a/test-kit/src/test/scala/format/BinaryFenTest.scala
+++ b/test-kit/src/test/scala/format/BinaryFenTest.scala
@@ -112,11 +112,15 @@ class BinaryFenTest extends ChessTest:
       EpdFen("r~n~b~q~kb~n~r~/pppppppp/8/8/8/8/PPPPPPPP/RN~BQ~KB~NR/ w KQkq - 0 499"),
       "ffff00000000ffff2d844ad200000000111111113e955be300e407060000000000ef0000000000002a"
     )
+    assertPersistence(
+      Crazyhouse,
+      EpdFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR/ w KQkq - 0 1"),
+      "ffff00000000ffff2d844ad200000000111111113e955be30000060000000000"
+    )
 
   private def assertRoundtrip(variant: Variant, fen: EpdFen) =
-    val situation = Fen.readWithMoveNumber(variant, fen).get
-    val bytes     = BinaryFen.write(situation)
-    println(bytes.value.map("%02x" format _).mkString)
+    val situation    = Fen.readWithMoveNumber(variant, fen).get
+    val bytes        = BinaryFen.write(situation)
     val roundtripped = BinaryFen.read(bytes)
     assertEquals(Fen.write(roundtripped), fen)
 

--- a/test-kit/src/test/scala/format/BinaryFenTest.scala
+++ b/test-kit/src/test/scala/format/BinaryFenTest.scala
@@ -27,6 +27,8 @@ class BinaryFenTest extends ChessTest:
 
     assertRoundtrip(Chess960, EpdFen("rn2k1r1/ppp1pp1p/3p2p1/5bn1/P7/2N2B2/1PPPPP2/2BNK1RR w Gkq - 4 11"))
 
+    assertRoundtrip(FromPosition, EpdFen("8/8/8/8/8/8/2Rk4/1K6 w - - 0 1"))
+
     assertRoundtrip(
       Horde,
       EpdFen("rn1qkb1r/3bn1p1/2p3P1/pPP2P2/P1PPP1P1/P1PP1PPP/PPPPPPPP/PPPPPPPP w kq a6 0 12")
@@ -70,11 +72,15 @@ class BinaryFenTest extends ChessTest:
     assertPersistence(Standard, EpdFen("5k2/6p1/8/1Pp5/6P1/8/8/3K4 w - c6 0 1"), "20400006400000080ac0b1")
     assertPersistence(Standard, EpdFen("4k3/8/8/8/3pP3/8/6N1/7K b - e3 0 1"), "10000000180040802ac10f")
     assertPersistence(
-      Standard,
+      Chess960,
       EpdFen("4rrk1/pbbp2p1/1ppnp3/3n1pqp/3N1PQP/1PPNP3/PBBP2P1/4RRK1 w Ff - 0 3"),
-      "704f1ee8e81e4f70d60a44000002020813191113511571be0004"
+      "704f1ee8e81e4f70d60a44000002020813191113511571be000402"
     )
-    assertPersistence(Standard, EpdFen("8/8/8/1k6/3Pp3/8/8/4KQ2 b - d3 3 1"), "00000002180000308a1c0f03")
+    assertPersistence(
+      FromPosition,
+      EpdFen("8/8/8/1k6/3Pp3/8/8/4KQ2 b - d3 3 1"),
+      "00000002180000308a1c0f030103"
+    )
     assertPersistence(
       Standard,
       EpdFen("r2r3k/p7/3p4/8/8/P6P/8/R3K2R b KQq - 0 4"),
@@ -84,38 +90,38 @@ class BinaryFenTest extends ChessTest:
     assertPersistence(
       KingOfTheHill,
       EpdFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"),
-      "ffff00000000ffff2d844ad200000000111111113e955be3000007"
+      "ffff00000000ffff2d844ad200000000111111113e955be3000004"
     )
     assertPersistence(
       ThreeCheck,
       EpdFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 99 1 +0+1"),
-      "ffff00000000ffff2d844ad200000000111111113e955be363000101"
+      "ffff00000000ffff2d844ad200000000111111113e955be363000501"
     )
-    assertPersistence(Antichess, EpdFen("8/7p/8/8/8/8/3K4/8 b - - 0 1"), "00800000000008001a000102")
+    assertPersistence(Antichess, EpdFen("8/7p/8/8/8/8/3K4/8 b - - 0 1"), "00800000000008001a000106")
     assertPersistence(
       Atomic,
       EpdFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 2 3"),
-      "ffff00000000ffff2d844ad200000000111111113e955be3020403"
+      "ffff00000000ffff2d844ad200000000111111113e955be3020407"
     )
     assertPersistence(
       Horde,
       EpdFen("rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1"),
-      "ffff0066ffffffff000000000000000000000000000000000000111111113e955be3000004"
+      "ffff0066ffffffff000000000000000000000000000000000000111111113e955be3000008"
     )
     assertPersistence(
       RacingKings,
       EpdFen("8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"),
-      "000000000000ffff793542867b3542a6000005"
+      "000000000000ffff793542867b3542a6000009"
     )
     assertPersistence(
       Crazyhouse,
       EpdFen("r~n~b~q~kb~n~r~/pppppppp/8/8/8/8/PPPPPPPP/RN~BQ~KB~NR/ w KQkq - 0 499"),
-      "ffff00000000ffff2d844ad200000000111111113e955be300e407060000000000ef0000000000002a"
+      "ffff00000000ffff2d844ad200000000111111113e955be300e407010000000000ef0000000000002a"
     )
     assertPersistence(
       Crazyhouse,
       EpdFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR/ w KQkq - 0 1"),
-      "ffff00000000ffff2d844ad200000000111111113e955be30000060000000000"
+      "ffff00000000ffff2d844ad200000000111111113e955be30000010000000000"
     )
 
   private def assertRoundtrip(variant: Variant, fen: EpdFen) =

--- a/test-kit/src/test/scala/format/BinaryFenTest.scala
+++ b/test-kit/src/test/scala/format/BinaryFenTest.scala
@@ -58,8 +58,69 @@ class BinaryFenTest extends ChessTest:
   test("fen fixtures"):
     for fen <- FenFixtures.fens do assertRoundtrip(Standard, fen)
 
+  test("persistence"):
+    assertPersistence(Standard, EpdFen("8/8/8/8/8/8/8/8 w - - 0 1"), "0000000000000000")
+    assertPersistence(Standard, EpdFen("8/8/8/8/8/8/8/8 b - - 0 1"), "00000000000000000001")
+    assertPersistence(Standard, EpdFen("8/8/8/8/8/8/8/8 b - - 100 432"), "000000000000000064df06")
+    assertPersistence(
+      Standard,
+      EpdFen("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1"),
+      "ffff00001000efff2d844ad200000000111111113e955fe3"
+    )
+    assertPersistence(Standard, EpdFen("5k2/6p1/8/1Pp5/6P1/8/8/3K4 w - c6 0 1"), "20400006400000080ac0b1")
+    assertPersistence(Standard, EpdFen("4k3/8/8/8/3pP3/8/6N1/7K b - e3 0 1"), "10000000180040802ac10f")
+    assertPersistence(
+      Standard,
+      EpdFen("4rrk1/pbbp2p1/1ppnp3/3n1pqp/3N1PQP/1PPNP3/PBBP2P1/4RRK1 w Ff - 0 3"),
+      "704f1ee8e81e4f70d60a44000002020813191113511571be0004"
+    )
+    assertPersistence(Standard, EpdFen("8/8/8/1k6/3Pp3/8/8/4KQ2 b - d3 3 1"), "00000002180000308a1c0f03")
+    assertPersistence(
+      Standard,
+      EpdFen("r2r3k/p7/3p4/8/8/P6P/8/R3K2R b KQq - 0 4"),
+      "8901080000810091ad0d10e1f70007"
+    )
+
+    assertPersistence(
+      KingOfTheHill,
+      EpdFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"),
+      "ffff00000000ffff2d844ad200000000111111113e955be3000007"
+    )
+    assertPersistence(
+      ThreeCheck,
+      EpdFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 99 1 +0+1"),
+      "ffff00000000ffff2d844ad200000000111111113e955be363000101"
+    )
+    assertPersistence(Antichess, EpdFen("8/7p/8/8/8/8/3K4/8 b - - 0 1"), "00800000000008001a000102")
+    assertPersistence(
+      Atomic,
+      EpdFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 2 3"),
+      "ffff00000000ffff2d844ad200000000111111113e955be3020403"
+    )
+    assertPersistence(
+      Horde,
+      EpdFen("rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1"),
+      "ffff0066ffffffff000000000000000000000000000000000000111111113e955be3000004"
+    )
+    assertPersistence(
+      RacingKings,
+      EpdFen("8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1"),
+      "000000000000ffff793542867b3542a6000005"
+    )
+    assertPersistence(
+      Crazyhouse,
+      EpdFen("r~n~b~q~kb~n~r~/pppppppp/8/8/8/8/PPPPPPPP/RN~BQ~KB~NR/ w KQkq - 0 499"),
+      "ffff00000000ffff2d844ad200000000111111113e955be300e407060000000000ef0000000000002a"
+    )
+
   private def assertRoundtrip(variant: Variant, fen: EpdFen) =
-    val situation    = Fen.readWithMoveNumber(variant, fen).get
-    val bytes        = BinaryFen.write(situation)
+    val situation = Fen.readWithMoveNumber(variant, fen).get
+    val bytes     = BinaryFen.write(situation)
+    println(bytes.value.map("%02x" format _).mkString)
     val roundtripped = BinaryFen.read(bytes)
     assertEquals(Fen.write(roundtripped), fen)
+
+  private def assertPersistence(variant: Variant, fen: EpdFen, hex: String) =
+    val situation = Fen.readWithMoveNumber(variant, fen).get
+    val bytes     = BinaryFen.write(situation)
+    assertEquals(bytes.value.map("%02x" format _).mkString, hex)

--- a/test-kit/src/test/scala/format/BinaryFenTest.scala
+++ b/test-kit/src/test/scala/format/BinaryFenTest.scala
@@ -6,8 +6,10 @@ import chess.variant.{ Standard, Variant }
 class BinaryFenTest extends ChessTest:
   test("roundtrip"):
     assertRoundtrip(Standard, "8/8/8/8/8/8/8/8 w - - 0 1")
+    assertRoundtrip(Standard, "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1")
 
   private def assertRoundtrip(variant: Variant, fen: String) =
     val situation    = Fen.readWithMoveNumber(variant, EpdFen(fen)).get
-    val roundtripped = BinaryFen.read(BinaryFen.write(situation))
+    val bytes        = BinaryFen.write(situation)
+    val roundtripped = BinaryFen.read(bytes)
     assertEquals(Fen.write(roundtripped), fen)

--- a/test-kit/src/test/scala/format/BinaryFenTest.scala
+++ b/test-kit/src/test/scala/format/BinaryFenTest.scala
@@ -1,13 +1,13 @@
 package chess
 package format
 
-import chess.variant.{ Variant, Standard }
+import chess.variant.{ Standard, Variant }
 
 class BinaryFenTest extends ChessTest:
   test("roundtrip"):
     assertRoundtrip(Standard, "8/8/8/8/8/8/8/8 w - - 0 1")
 
   private def assertRoundtrip(variant: Variant, fen: String) =
-    val situation = Fen.readWithMoveNumber(variant, EpdFen(fen)).get
+    val situation    = Fen.readWithMoveNumber(variant, EpdFen(fen)).get
     val roundtripped = BinaryFen.read(BinaryFen.write(situation))
     assertEquals(Fen.write(roundtripped), fen)

--- a/test-kit/src/test/scala/format/BinaryFenTest.scala
+++ b/test-kit/src/test/scala/format/BinaryFenTest.scala
@@ -1,0 +1,13 @@
+package chess
+package format
+
+import chess.variant.{ Variant, Standard }
+
+class BinaryFenTest extends ChessTest:
+  test("roundtrip"):
+    assertRoundtrip(Standard, "8/8/8/8/8/8/8/8 w - - 0 1")
+
+  private def assertRoundtrip(variant: Variant, fen: String) =
+    val situation = Fen.readWithMoveNumber(variant, EpdFen(fen)).get
+    val roundtripped = BinaryFen.read(BinaryFen.write(situation))
+    assertEquals(Fen.write(roundtripped), fen)


### PR DESCRIPTION
* Information stored: Complete FEN (including move numbers, position not necessarily legal, invalid castling rights / ep may be lost) + variant

   ```
   Situation.AndFullMoveNumber <=> Array[Byte]
   ```

* Relatively compact packing (but still further compressible with entropy coding). Examples:

   fen | EpdFen | SmallFen | BinaryFen
   --- | --- | --- | ---
   rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1 | 58 bytes | 43 bytes | 24 bytes
   QN4n1/6r1/3k4/8/b2K4/8/8/8 b - - 0 1 | 36 bytes | 20 bytes | 12 bytes

* Main part of the encoding adapted from https://github.com/official-stockfish/nnue-pytorch/blob/master/lib/nnue_training_data_formats.h#L4607.

* Move numbers not needed? The default of `0 1` is particularly efficient.

* Quite fast:
  - order of 5 million reads / second
  - order of 3 million writes / second