### PR TITLE
Additional castling tests & test name cleanup

### DIFF
--- a/test-kit/src/test/scala/CastlingTest.scala
+++ b/test-kit/src/test/scala/CastlingTest.scala
@@ -42,7 +42,7 @@ class CastlingTest extends ChessTest:
     val board: Board = """R  QK  R"""
     assertEquals(board.place(Black.rook, H3).flatMap(_.destsFrom(E1)), Set(D2, E2, F1, F2, G1, H1))
 
-  test("threat on rook does not prevent castling king side"):
+  test("threat on rook does not prevent castling queen side"):
     val board: Board = """R   KB R"""
     assertEquals(board.place(Black.rook, A3).flatMap(_.destsFrom(E1)), Set(A1, C1, D1, D2, E2, F2))
 

--- a/test-kit/src/test/scala/CastlingTest.scala
+++ b/test-kit/src/test/scala/CastlingTest.scala
@@ -23,6 +23,9 @@ class CastlingTest extends ChessTest:
   test("threat on king prevents castling: by a knight"):
     assertEquals(board.place(Black.knight, D3).flatMap(_.destsFrom(E1)), Set(D1, D2, E2, F1))
 
+  test("threat on king prevents castling: by a bishop"):
+    assertEquals(board.place(Black.bishop, A5).flatMap(_.destsFrom(E1)), Set(D1, E2, F2, F1))
+
   test("threat on castle trip prevents castling: king side"):
     val board: Board = """R  QK  R"""
     assertEquals(board.place(Black.rook, F3).flatMap(_.destsFrom(E1)), Set(D2, E2))

--- a/test-kit/src/test/scala/CastlingTest.scala
+++ b/test-kit/src/test/scala/CastlingTest.scala
@@ -49,6 +49,10 @@ class CastlingTest extends ChessTest:
     val board: Board = """R   KB R"""
     assertEquals(board.place(Black.rook, A3).flatMap(_.destsFrom(E1)), Set(A1, C1, D1, D2, E2, F2))
 
+  test("threat on rooks trip does not prevent castling queen side"):
+    val board: Board = """R   KB R"""
+    assertEquals(board.place(Black.rook, B3).flatMap(_.destsFrom(E1)), Set(A1, C1, D1, D2, E2, F2))
+
   test("unmovedRooks and castles are consistent"):
     val s1 = Fen.read(Standard, Fen.Full("rnbqk2r/pppppppp/8/8/8/8/PPPPPPPP/RNBQK2R w Qq - 0 1")).get
     val s2 = s1.focus(_.board.history.unmovedRooks).replace(UnmovedRooks.corners)

--- a/test-kit/src/test/scala/PawnTest.scala
+++ b/test-kit/src/test/scala/PawnTest.scala
@@ -7,7 +7,7 @@ class PawnTest extends ChessTest:
 
   import compare.dests
 
-  test("move towards rank by 1 square"):
+  test("move towards rank by 1 square (white pawn)"):
     assertEquals(
       makeBoard(
         A4 -> White.pawn
@@ -15,7 +15,7 @@ class PawnTest extends ChessTest:
       Set(A5)
     )
 
-  test("not move to positions that are occupied by the same color"):
+  test("not move to positions that are occupied by the same color (white pawn)"):
     assertEquals(
       makeBoard(
         A4 -> White.pawn,
@@ -24,7 +24,7 @@ class PawnTest extends ChessTest:
       Set()
     )
 
-  test("capture in diagonal"):
+  test("capture in diagonal (white pawn)"):
     assertEquals(
       makeBoard(
         D4 -> White.pawn,
@@ -34,7 +34,7 @@ class PawnTest extends ChessTest:
       Set(C5, D5, E5)
     )
 
-  test("require a capture to move in diagonal"):
+  test("require a capture to move in diagonal (white pawn)"):
     assertEquals(
       makeBoard(
         A4 -> White.pawn,
@@ -43,7 +43,7 @@ class PawnTest extends ChessTest:
       Set(A5)
     )
 
-  test("move towards rank by 2 squares"):
+  test("move towards rank by 2 squares (white pawn)"):
     // "if the path is free" in:
     assertEquals(
       makeBoard(
@@ -85,7 +85,7 @@ class PawnTest extends ChessTest:
       ).destsFrom(A2),
       Set(A3)
     )
-  test("capture en passant"):
+  test("capture en passant (white pawn)"):
     // "with proper position" in:
     val board = makeBoard(
       D5 -> White.pawn,
@@ -152,7 +152,7 @@ class PawnTest extends ChessTest:
       Set(D6)
     )
 
-  test("move towards rank by 1 square"):
+  test("move towards rank by 1 square (black pawn)"):
     assertEquals(
       makeBoard(
         A4 -> Black.pawn
@@ -160,7 +160,7 @@ class PawnTest extends ChessTest:
       Set(A3)
     )
 
-  test("not move to positions that are occupied by the same color"):
+  test("not move to positions that are occupied by the same color (black pawn)"):
     assertEquals(
       makeBoard(
         A4 -> Black.pawn,
@@ -169,7 +169,7 @@ class PawnTest extends ChessTest:
       Set()
     )
 
-  test("capture in diagonal"):
+  test("capture in diagonal (black pawn)"):
     assertEquals(
       makeBoard(
         D4 -> Black.pawn,
@@ -179,7 +179,7 @@ class PawnTest extends ChessTest:
       Set(C3, D3, E3)
     )
 
-  test("require a capture to move in diagonal"):
+  test("require a capture to move in diagonal (black pawn)"):
     assertEquals(
       makeBoard(
         A4 -> Black.pawn,
@@ -188,7 +188,7 @@ class PawnTest extends ChessTest:
       Set(A3)
     )
 
-  test("move towards rank by 2 squares"):
+  test("move towards rank by 2 squares (black pawn)"):
     // "if the path is free" in:
     assertEquals(
       makeBoard(
@@ -230,7 +230,7 @@ class PawnTest extends ChessTest:
       ).destsFrom(A7),
       Set(A6)
     )
-  test("capture en passant"):
+  test("capture en passant (black pawn)"):
     // "with proper position" in:
     val board = makeBoard(
       D4 -> Black.pawn,


### PR DESCRIPTION
In test output, there were some confusing "duplicated" test cases being run. Upon closer inspection they were not duplicates, but their names were somewhat misleading.

- Castling tests: there was duplicate "queen side" test, where the other was in fact "king side" test incorrectly named
- Pawn tests: there was "duplicate" for every test, but apparently first ones were white pawn tests and latter ones black pawn tests. Rename them to give clear output which one is being tested.

While checking these, I also added additional castling tests. Nothing of note was revealed through them, but adds a bit of coverage for different scenarios.

- Bishop variant of threat. Sibling to current knight/rook tests.
- Threat on rooks trip during castling move.