### PR TITLE
Use match instead of pipe

### DIFF
--- a/core/src/main/scala/format/pgn/Reader.scala
+++ b/core/src/main/scala/format/pgn/Reader.scala
@@ -3,8 +3,6 @@ package format.pgn
 
 import cats.syntax.all.*
 
-import util.chaining.scalaUtilChainingOps
-
 object Reader:
 
   sealed trait Result:
@@ -46,5 +44,6 @@ object Reader:
         case Right(replay)     => Result.Complete(replay)
 
   private def makeGame(tags: Tags) =
-    Game(variantOption = tags.variant, fen = tags.fen).pipe: self =>
-      self.copy(startedAtPly = self.ply, clock = tags.clockConfig.map(Clock.apply))
+    Game(variantOption = tags.variant, fen = tags.fen).match
+      case self =>
+        self.copy(startedAtPly = self.ply, clock = tags.clockConfig.map(Clock.apply))


### PR DESCRIPTION
With .match We have an equivalent of `pipe` without extra allocation: https://gist.github.com/lenguyenthanh/6dd8ff4b3cafc0d016fd9e86d1022d5f