### PR TITLE
Simplify PgnNodeEncoder Trait

### DIFF
--- a/bench/src/main/scala/benchmarks/PgnBench.scala
+++ b/bench/src/main/scala/benchmarks/PgnBench.scala
@@ -5,8 +5,7 @@ import org.openjdk.jmh.infra.Blackhole
 import java.util.concurrent.TimeUnit
 
 import cats.syntax.all.*
-import chess.format.pgn.{ Fixtures, Parser, Pgn, PgnStr }
-import chess.format.pgn.ParsedPgn
+import chess.format.pgn.{ Fixtures, ParsedPgn, Parser, Pgn, PgnStr }
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))

--- a/core/src/main/scala/format/pgn/Pgn.scala
+++ b/core/src/main/scala/format/pgn/Pgn.scala
@@ -58,7 +58,7 @@ case class Move(
   def hasComment =
     comments.nonEmpty || secondsLeft.isDefined || opening.isDefined || result.isDefined
 
-  def render(builder: StringBuilder) =
+  private def appendSanStr(builder: StringBuilder): Unit =
     builder.append(san.value)
     glyphs.toList.foreach:
       case glyph if glyph.id <= 6 => builder.append(glyph.symbol)
@@ -68,12 +68,17 @@ case class Move(
         .:::(comments.map(_.map(Move.noDoubleLineBreak)))
         .foreach(x => builder.append(" { ").append(x).append(" }"))
 
+  def render: String =
+    val builder = new StringBuilder
+    appendSanStr(builder)
+    builder.toString
+
 object Move:
 
   given PgnNodeEncoder[Move] with
     extension (m: Move)
-      def render(builder: StringBuilder) = m.render(builder)
-      def renderVariationComment(builder: StringBuilder) =
+      def appendSanStr(builder: StringBuilder) = m.appendSanStr(builder)
+      def appendVariationComment(builder: StringBuilder) =
         m.variationComments.foreach(x => builder.append(" { ").append(x.value).append(" }"))
       def hasComment = m.hasComment
 

--- a/core/src/main/scala/format/pgn/PgnNodeEncoder.scala
+++ b/core/src/main/scala/format/pgn/PgnNodeEncoder.scala
@@ -8,8 +8,8 @@ package format.pgn
  */
 trait PgnNodeEncoder[A]:
   extension (a: A)
-    def render(builder: StringBuilder): Unit
-    def renderVariationComment(builder: StringBuilder): Unit
+    def appendSanStr(builder: StringBuilder): Unit
+    def appendVariationComment(builder: StringBuilder): Unit
     def hasComment: Boolean
 
 object PgnNodeEncoder:
@@ -40,7 +40,7 @@ object PgnNodeEncoder:
 
     @annotation.tailrec
     private def render(builder: StringBuilder, forceTurnNumber: Boolean, ply: Ply): Unit =
-      if tree.isVariation then tree.value.renderVariationComment(builder)
+      if tree.isVariation then tree.value.appendVariationComment(builder)
       tree.addTurnNumberPrefix(forceTurnNumber, builder, ply)
       renderValueAndVariations(builder, ply)
       tree.child.match
@@ -59,7 +59,7 @@ object PgnNodeEncoder:
       else if forceTurnNumber then builder.append(ply.turnNumber).append("... ")
 
     private def renderValueAndVariations(builder: StringBuilder, ply: Ply) =
-      tree.value.render(builder)
+      tree.value.appendSanStr(builder)
       tree.variations.foreach: x =>
         builder.addOne(' ').addOne('(')
         x.appendPgnStr(builder, ply)

--- a/core/src/main/scala/format/pgn/PgnNodeEncoder.scala
+++ b/core/src/main/scala/format/pgn/PgnNodeEncoder.scala
@@ -14,12 +14,6 @@ trait PgnNodeEncoder[A]:
 
 object PgnNodeEncoder:
 
-  extension (ply: Ply)
-    private def isWhiteTurn: Boolean =
-      ply.turn.black
-    private def turnNumber: FullMoveNumber = // calculate turn number directly
-      if ply.turn.black then ply.fullMoveNumber else ply.fullMoveNumber - 1
-
   extension [A](tree: Tree[A])(using PgnNodeEncoder[A])
 
     /**
@@ -70,3 +64,9 @@ object PgnNodeEncoder:
         builder.addOne(' ').addOne('(')
         x.appendPgnStr(builder, ply)
         builder.addOne(')')
+
+  extension (ply: Ply)
+    private def isWhiteTurn: Boolean =
+      ply.isOdd
+    private def turnNumber: FullMoveNumber =
+      ply.fullMoveNumber + ply.value % 2 - 1

--- a/core/src/main/scala/format/pgn/parsingModel.scala
+++ b/core/src/main/scala/format/pgn/parsingModel.scala
@@ -6,8 +6,6 @@ import chess.format.Fen
 
 import MoveOrDrop.*
 
-private case class MappingContext(situation: Situation, ply: Ply)
-
 // We don't support variation without move now,
 // but we can in the future when we support null move
 case class PgnNodeData(
@@ -21,13 +19,12 @@ case class PgnNodeData(
 ):
   export metas.*
 
-  def toMove(context: MappingContext): Option[(Situation, Move)] =
-    san(context.situation).toOption
+  def toMove(context: Situation): Option[(Situation, Move)] =
+    san(context).toOption
       .map(x =>
         (
           x.situationAfter,
           Move(
-            ply = context.ply.next,
             san = x.toSanStr,
             comments = comments,
             glyphs = glyphs,
@@ -42,27 +39,26 @@ case class PgnNodeData(
 type ParsedPgnTree = Node[PgnNodeData]
 
 extension (tree: ParsedPgnTree)
-  private def toPgn(context: MappingContext): Option[Node[Move]] =
+  private def toPgn(context: Situation): Option[Node[Move]] =
     tree.mapAccumlOption_(context): (ctx, d) =>
       d.toMove(ctx)
         .fold(ctx -> None): (sit, m) =>
-          MappingContext(sit, ctx.ply.next) -> m.some
+          sit -> m.some
 
 case class ParsedPgn(initialPosition: InitialComments, tags: Tags, tree: Option[ParsedPgnTree]):
   def mainline = tree.fold(List.empty[San])(_.mainline.map(_.value.san))
 
   def toPgn: Pgn =
-    Pgn(tags, initialPosition, tree.flatMap(_.toPgn(initContext(tags))))
+    val sitWithMove = initContext(tags)
+    Pgn(tags, initialPosition, tree.flatMap(_.toPgn(sitWithMove.situation)), sitWithMove.ply.next)
 
-  private def initContext(tags: Tags): MappingContext =
+  private def initContext(tags: Tags) =
     val variant = tags.variant | chess.variant.Standard
     def default = Situation.AndFullMoveNumber(Situation(Board.init(variant), White), FullMoveNumber.initial)
 
-    val sitWithMoves = tags.fen
+    tags.fen
       .flatMap(Fen.readWithMoveNumber(variant, _))
       .getOrElse(default)
-
-    MappingContext(sitWithMoves.situation, sitWithMoves.ply)
 
 // Standard Algebraic Notation
 sealed trait San:

--- a/core/src/main/scala/format/pgn/parsingModel.scala
+++ b/core/src/main/scala/format/pgn/parsingModel.scala
@@ -56,8 +56,8 @@ case class ParsedPgn(initialPosition: InitialComments, tags: Tags, tree: Option[
   private def treeToPgn(context: Situation): Option[Node[Move]] =
     tree.flatMap:
       _.mapAccumlOption_(context): (ctx, d) =>
-          d.toMove(ctx)
-            .fold(ctx -> None)(_ -> _.some)
+        d.toMove(ctx)
+          .fold(ctx -> None)(_ -> _.some)
 
 // Standard Algebraic Notation
 sealed trait San:

--- a/test-kit/src/test/scala/format/pgn/RoundtripTest.scala
+++ b/test-kit/src/test/scala/format/pgn/RoundtripTest.scala
@@ -6,7 +6,7 @@ class RoundtripTest extends ChessTest:
   test("roundtrip with special chars for tags"):
     val value = "aä\\\"'$%/°á \t\b \"\\\\/"
     val parsed = Parser
-      .full(Pgn(tags = Tags(List(Tag(_.Site, value))), InitialComments.empty, None).render)
+      .full(Pgn(tags = Tags(List(Tag(_.Site, value))), InitialComments.empty, None, Ply.initial).render)
       .toOption
       .get
     assertEquals(parsed.tags("Site"), Some(value))


### PR DESCRIPTION
If the We have the tree and a starting ply, then We don't really need Ply
for each pgn node. We can increment ply when traversing the tree. This
will reduce the complexity for generating PGN from other structure as We
don't have to increment ply when generating PgnNodeEncoder. This also
give us an option to not include turn number in pgn.

[benchmark](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/lenguyenthanh/44d2df060d6cab4c9deebef0c18df4aa/raw/88a982f1b1cfbb170e78e078849d95b6365d47fe/before.json,https://gist.githubusercontent.com/lenguyenthanh/44d2df060d6cab4c9deebef0c18df4aa/raw/88a982f1b1cfbb170e78e078849d95b6365d47fe/after3.json) show a bit of improvement as well