### PR TITLE
Restore lag comp quota behavior

### DIFF
--- a/core/src/main/scala/LagTracker.scala
+++ b/core/src/main/scala/LagTracker.scala
@@ -62,7 +62,7 @@ final case class LagTracker(
 
 object LagTracker:
 
-  private val estimatedCpuLag = Centis(4)
+  private val estimatedCpuLag = Centis(14)
 
   // https://github.com/lichess-org/lila/issues/12097
   private def maxQuotaGainFor(config: Clock.Config) =


### PR DESCRIPTION
Lag comp quota is intended to build up each turn so that it can be used for spikes.  The current code depletes quota on slow computers, and even for computers with cpu lag below .04s, quota builds too slowly to be able to be used for multiple spikes in a game.

This patch is intended to be a short term fix, with a significant code and documentation overhaul planned in the near future.