### PR TITLE
Implement literal pgn

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ lazy val testKit = project
     name := "scalachess-test-kit",
     libraryDependencies ++= List(
       "org.scalacheck"      %% "scalacheck"        % "1.18.1",
+      "org.typelevel"       %% "literally"         % "1.2.0",
       "org.scalameta"       %% "munit"             % "1.0.2"  % Test,
       "org.scalameta"       %% "munit-scalacheck"  % "1.0.0"  % Test,
       "com.disneystreaming" %% "weaver-cats"       % "0.8.4"  % Test,

--- a/test-kit/src/main/scala/chess/pgn.scala
+++ b/test-kit/src/main/scala/chess/pgn.scala
@@ -1,0 +1,16 @@
+package chess
+package format.pgn
+
+import cats.syntax.all.*
+import org.typelevel.literally.Literally
+
+object macros:
+  extension (inline ctx: StringContext)
+    inline def pgn(inline args: Any*): ParsedPgn =
+      ${ PgnLiteral('ctx, 'args) }
+
+  object PgnLiteral extends Literally[ParsedPgn]:
+    def validate(s: String)(using Quotes) =
+      Parser.full(PgnStr(s)) match
+        case Right(parsed) => Right('{ Parser.full(PgnStr(${ Expr(s) })).toOption.get })
+        case Left(err)     => Left(err.toString)

--- a/test-kit/src/test/scala/format/pgn/MacrosTest.scala
+++ b/test-kit/src/test/scala/format/pgn/MacrosTest.scala
@@ -1,0 +1,10 @@
+package chess
+package format.pgn
+
+class MacrosTest extends munit.FunSuite:
+
+  import macros.*
+  test("pgn macro"):
+    val pgn = pgn"1. e4 e5 2. Nf3 Nc6"
+    assert(pgn.tree.isDefined)
+    assertEquals(pgn.toPgn.toString, "1. e4 e5 2. Nf3 Nc6")


### PR DESCRIPTION
I put it in testKit for now, as I don't see using it in prod. But could be useful for testing.

the usage is in the tests:
```scala
  import macros.*
  test("pgn macro"):
    val pgn = pgn"1. e4 e5 2. Nf3 Nc6" // We validate this at compile time.
    assert(pgn.tree.isDefined)
    assertEquals(pgn.toPgn.toString, "1. e4 e5 2. Nf3 Nc6")
```