### PR TITLE
throw away lsb rather than msb of position hashes

### DIFF
--- a/core/src/main/scala/Hash.scala
+++ b/core/src/main/scala/Hash.scala
@@ -29,7 +29,7 @@ object PositionHash:
 opaque type Hash = Int
 object Hash:
   val size                              = 3
-  def apply(value: Int): Hash           = value & 0x00ff_ffff
+  def apply(value: Int): Hash           = value >>> 8
   def apply(situation: Situation): Hash = hashSituation(situation) >>> 8
 
   private def hashSituation(situation: Situation): Int =

--- a/core/src/main/scala/Hash.scala
+++ b/core/src/main/scala/Hash.scala
@@ -30,7 +30,7 @@ opaque type Hash = Int
 object Hash:
   val size                              = 3
   def apply(value: Int): Hash           = value & 0x00ff_ffff
-  def apply(situation: Situation): Hash = hashSituation(situation) & 0x00ff_ffff
+  def apply(situation: Situation): Hash = hashSituation(situation) >>> 8
 
   private def hashSituation(situation: Situation): Int =
     import situation.board

--- a/test-kit/src/test/scala/HistoryTest.scala
+++ b/test-kit/src/test/scala/HistoryTest.scala
@@ -2,7 +2,7 @@ package chess
 
 class ThreefoldRepetitionTest extends ChessTest:
 
-  def toHash(a: Int) = PositionHash(Hash(a))
+  def toHash(a: Int) = PositionHash(Hash(a << 8))
   def makeHistory(positions: List[Int]) =
     (positions
       .map(toHash))


### PR DESCRIPTION
for compatibility with lichess-org/compression

fix [#16317](https://github.com/lichess-org/lila/issues/16317)