### PR TITLE
Remove non-existent opening from starting positions

### DIFF
--- a/core/src/main/scala/StartingPosition.scala
+++ b/core/src/main/scala/StartingPosition.scala
@@ -133,7 +133,6 @@ object StartingPosition:
         of(StandardFen("r1bqk2r/pp3ppp/2nppn2/2p5/2PP4/2PBPN2/P4PPP/R1BQK2R w KQkq -")),
         of(StandardFen("rnbqk2r/pppp1ppp/4pn2/8/1bPP4/2N2N2/PP2PPPP/R1BQKB1R b KQkq -")),
         of(StandardFen("rnbqk2r/pppp1ppp/4pn2/6B1/1bPP4/2N5/PP2PPPP/R2QKBNR b KQkq -")),
-        of(StandardFen("rnbqk2r/pppp1ppp/4pn2/8/2PP4/P1P5/4PPPP/R1BQKBNR b KQkq -")),
         of(StandardFen("rnbqkb1r/ppp1pppp/3p1n2/8/2PP4/8/PP2PPPP/RNBQKBNR w KQkq -")),
         of(StandardFen("rnbqkbnr/ppp1pppp/8/3p4/2PP4/8/PP2PPPP/RNBQKBNR b KQkq -")),
         of(StandardFen("rnbqkbnr/ppp1pppp/8/8/2pP4/8/PP2PPPP/RNBQKBNR w KQkq -")),


### PR DESCRIPTION
This used to be known as "Nimzo-Indian Defense: Sämisch Variation, Accelerated" but was removed from the openings db in https://github.com/lichess-org/chess-openings/pull/219.

This starting position therefore now resolves to an empty optional and isn't actually used.

Side note: This actually caused the order of all the daily opening tournaments to be reshuffled completely.