### PR TITLE
Use sequence.get instead of flatten for StartingPosition

### DIFF
--- a/core/src/main/scala/StartingPosition.scala
+++ b/core/src/main/scala/StartingPosition.scala
@@ -1,5 +1,6 @@
 package chess
 
+import cats.syntax.all.*
 import chess.format.StandardFen
 import chess.opening.{ Opening, OpeningDb }
 
@@ -96,7 +97,7 @@ object StartingPosition:
         of(StandardFen("r1bqkb1r/pppp1ppp/2n2n2/4N3/4P3/2N5/PPPP1PPP/R1BQKB1R b KQkq -")),
         of(StandardFen("rnbqkbnr/pppp1ppp/8/4p2Q/4P3/8/PPPP1PPP/RNB1KBNR b KQkq -")),
         of(StandardFen("rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPPKPPP/RNBQ1BNR b kq -"), featurable = false)
-      ).flatten
+      ).sequence.get
     ),
     Category(
       "d4",
@@ -151,7 +152,7 @@ object StartingPosition:
         of(StandardFen("rnbqkb1r/pppp1ppp/5n2/4p3/2PP4/8/PP2PPPP/RNBQKBNR w KQkq -"), featurable = false),
         of(StandardFen("rnbqkbnr/ppp1pppp/8/3p4/3P4/8/PPP1PPPP/RNBQKBNR w KQkq -"), featurable = false),
         of(StandardFen("rnbqkb1r/pppppppp/5n2/6B1/3P4/8/PPP1PPPP/RN1QKBNR b KQkq -"))
-      ).flatten
+      ).sequence.get
     ),
     Category(
       "Nf3",
@@ -159,7 +160,7 @@ object StartingPosition:
         of(StandardFen("rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQKB1R b KQkq -"), featurable = false),
         of(StandardFen("rnbqkbnr/ppp1pppp/8/3p4/8/5NP1/PPPPPP1P/RNBQKB1R b KQkq -")),
         of(StandardFen("rnbqkbnr/ppp1pppp/8/3p4/2P5/5N2/PP1PPPPP/RNBQKB1R b KQkq -"))
-      ).flatten
+      ).sequence.get
     ),
     Category(
       "c4",
@@ -168,43 +169,44 @@ object StartingPosition:
         of(StandardFen("rnbqkbnr/pppp1ppp/8/4p3/2P5/8/PP1PPPPP/RNBQKBNR w KQkq -")),
         of(StandardFen("rnbqkbnr/pp1ppppp/8/2p5/2P5/8/PP1PPPPP/RNBQKBNR w KQkq -")),
         of(StandardFen("r1bqk1nr/ppp2pbp/2np2p1/4p3/2P5/2NP2P1/PP2PPBP/R1BQK1NR w KQkq -"))
-      ).flatten
+      ).sequence.get
     ),
     Category(
       "b3",
       List(
         of(StandardFen("rnbqkbnr/pppppppp/8/8/8/1P6/P1PPPPPP/RNBQKBNR b KQkq -"), featurable = false)
-      ).flatten
+      ).sequence.get
     ),
     Category(
       "b4",
       List(
         of(StandardFen("rnbqkbnr/pppppppp/8/8/1P6/8/P1PPPPPP/RNBQKBNR b KQkq -"), featurable = false)
-      ).flatten
+      ).sequence.get
     ),
     Category(
       "f4",
       List(
         of(StandardFen("rnbqkbnr/pppppppp/8/8/5P2/8/PPPPP1PP/RNBQKBNR b KQkq -")),
         of(StandardFen("rnbqkbnr/ppp1pppp/8/3p4/5P2/8/PPPPP1PP/RNBQKBNR w KQkq -"))
-      ).flatten
+      ).sequence.get
     ),
     Category(
       "g3",
       List(
         of(StandardFen("rnbqkbnr/pppppppp/8/8/8/6P1/PPPPPP1P/RNBQKBNR b KQkq -"), featurable = false)
-      ).flatten
+      ).sequence.get
     )
   )
 
   val all: IndexedSeq[StartingPosition] = categories.flatMap(_.positions).toIndexedSeq
 
-  lazy val featurable = scala.util.Random(475591).shuffle(all.filter(_.featurable))
+  lazy val featurable: IndexedSeq[StartingPosition] =
+    scala.util.Random(475591).shuffle(all.filter(_.featurable))
 
-  def randomFeaturable = featurable(scala.util.Random.nextInt(featurable.size))
+  def randomFeaturable: StartingPosition = featurable(scala.util.Random.nextInt(featurable.size))
 
   private def of(fen: StandardFen, featurable: Boolean = true): Option[StartingPosition] =
-    OpeningDb.findByStandardFen(fen).map { StartingPosition(_, featurable) }
+    OpeningDb.findByStandardFen(fen).map(StartingPosition(_, featurable))
 
   object presets:
     val halloween    = of(StandardFen("r1bqkb1r/pppp1ppp/2n2n2/4N3/4P3/2N5/PPPP1PPP/R1BQKB1R b KQkq -"))

--- a/test-kit/src/test/scala/opening/StartingPositionTest.scala
+++ b/test-kit/src/test/scala/opening/StartingPositionTest.scala
@@ -1,0 +1,9 @@
+package chess
+package opening
+
+class StartingPositionTest extends ChessTest:
+
+  // simple test to guard against faulty starting positions
+  test("search should find the starting position"):
+    StartingPosition.all.foreach: p =>
+      assert(p.featurable || true)


### PR DESCRIPTION
This will crash instead of silently ignore faulty starting positions. Which is safe as we also add tests to guard against those cases.

Related to #638 