### PR TITLE
Add `mainline` and `mainlineWithMetas` to pgn.Parser

### DIFF
--- a/bench/src/main/scala/benchmarks/BinaryFenBench.scala
+++ b/bench/src/main/scala/benchmarks/BinaryFenBench.scala
@@ -47,6 +47,7 @@ class BinaryFenBench:
       val game = games(i)
       Blackhole.consumeCPU(Work)
       bh.consume(BinaryFen.write(game))
+      i += 1
 
   @Benchmark
   def read(bh: Blackhole) =

--- a/bench/src/main/scala/benchmarks/PgnBench.scala
+++ b/bench/src/main/scala/benchmarks/PgnBench.scala
@@ -30,12 +30,24 @@ class PgnBench:
     pgns = pgnStrs.traverse(Parser.full).toOption.get.map(_.toPgn)
 
   @Benchmark
-  def pgnParser(bh: Blackhole) =
-    val result = pgnStrs.map: x =>
+  def pgnFullParser(bh: Blackhole) =
+    var games = this.pgnStrs
+    var i     = 0
+    while i < games.size do
+      val game = games(i)
       Blackhole.consumeCPU(Work)
-      Parser.full(x)
-    bh.consume(result)
-    result
+      bh.consume(Parser.full(game))
+      i += 1
+
+  @Benchmark
+  def pgnMainlineParser(bh: Blackhole) =
+    var games = this.pgnStrs
+    var i     = 0
+    while i < games.size do
+      val game = games(i)
+      Blackhole.consumeCPU(Work)
+      bh.consume(Parser.mainline(game))
+      i += 1
 
   @Benchmark
   def pgnRender(bh: Blackhole) =

--- a/bench/src/main/scala/benchmarks/PgnBench.scala
+++ b/bench/src/main/scala/benchmarks/PgnBench.scala
@@ -40,6 +40,16 @@ class PgnBench:
       i += 1
 
   @Benchmark
+  def pgnMainlineWithMetasParser(bh: Blackhole) =
+    var games = this.pgnStrs
+    var i     = 0
+    while i < games.size do
+      val game = games(i)
+      Blackhole.consumeCPU(Work)
+      bh.consume(Parser.mainlineWithMetas(game))
+      i += 1
+
+  @Benchmark
   def pgnMainlineParser(bh: Blackhole) =
     var games = this.pgnStrs
     var i     = 0

--- a/core/src/main/scala/Replay.scala
+++ b/core/src/main/scala/Replay.scala
@@ -57,7 +57,7 @@ object Replay:
       .foldM((init, emptyGames)):
         case ((head, games), str) =>
           Parser
-            .sanOnly(str)
+            .san(str)
             .flatMap: san =>
               san(head.situation)
                 .map: move =>

--- a/core/src/main/scala/format/pgn/Parser.scala
+++ b/core/src/main/scala/format/pgn/Parser.scala
@@ -226,9 +226,9 @@ object Parser:
     (TagParser.tags.surroundedBy(escape) ~ p.?).map: (optionalTags, optionalMoves) =>
       val preTags = Tags.sanitize(optionalTags)
       optionalMoves match
-        case None => ParsedMainline(preTags, Nil)
-        case Some((_, sans, result)) =>
-          ParsedMainline(updateTagsWithResult(preTags, result), sans)
+        case None => ParsedMainline(InitialComments.empty, preTags, Nil)
+        case Some((init, sans, result)) =>
+          ParsedMainline(init, updateTagsWithResult(preTags, result), sans)
 
   private inline def updateTagsWithResult(tags: Tags, result: Option[String]): Tags =
     result.filterNot(_ => tags.exists(_.Result)).foldLeft(tags)(_ + Tag(_.Result, _))

--- a/core/src/main/scala/format/pgn/Parser.scala
+++ b/core/src/main/scala/format/pgn/Parser.scala
@@ -74,7 +74,7 @@ object Parser:
   private val postMoveEscape = moveExtras.rep0.void <* escape
 
   private val sanOnly: P[San] =
-    escapeVariations(SanParser.san)
+    preMoveEscape.with1 *> SanParser.san
 
   private val sanAndMetasOnly: P[SanWithMetas] =
     escapeVariations(moveAndMetas.map(SanWithMetas.apply))

--- a/core/src/main/scala/format/pgn/Parser.scala
+++ b/core/src/main/scala/format/pgn/Parser.scala
@@ -89,18 +89,18 @@ object Parser:
     escapeVariations(moveAndMetas.map(SanWithMetas.apply))
 
   private def escapeVariations[A](p: P[A]): P[A] =
-    P.recursive[A] { recuse =>
+    P.recursive[A] { recurse =>
       val variation: P[Unit] =
-        (P.char('(') *> comment.rep0.surroundedBy(escape) *> recuse.rep0 *> P.char(')') *> escape).void
+        (P.char('(') *> comment.rep0.surroundedBy(escape) *> recurse.rep0 *> P.char(')') *> escape).void
       (preMoveEscape.with1 *> (p <* variation.rep0) <* postMoveEscape)
     }
 
   private val moveParser: P[Node[PgnNodeData]] =
-    P.recursive[Node[PgnNodeData]] { recuse =>
+    P.recursive[Node[PgnNodeData]] { recurse =>
       // TODO: if a variation only contains comments, we ignore it
       // Will fix it after support null move
       val variation: P[Option[Variation[PgnNodeData]]] =
-        (P.char('(') *> comment.rep0.surroundedBy(escape) ~ recuse.rep0 <* (P.char(')') ~ escape))
+        (P.char('(') *> comment.rep0.surroundedBy(escape) ~ recurse.rep0 <* (P.char(')') ~ escape))
           .map((comments, sans) =>
             sans match
               case Nil => None

--- a/core/src/main/scala/format/pgn/Reader.scala
+++ b/core/src/main/scala/format/pgn/Reader.scala
@@ -23,8 +23,7 @@ object Reader:
   def fullWithSans(pgn: PgnStr, op: Sans => Sans, tags: Tags = Tags.empty): Either[ErrorStr, Result] =
     Parser
       .mainline(pgn)
-      .map: parsed =>
-        makeReplay(makeGame(parsed.tags ++ tags), op(Sans(parsed.sans.map(_.san))))
+      .map(parsed => makeReplay(makeGame(parsed.tags ++ tags), op(Sans(parsed.sans))))
 
   def fullWithSans(parsed: ParsedPgn, op: Sans => Sans): Result =
     makeReplay(makeGame(parsed.tags), op(Sans(parsed.mainline)))

--- a/core/src/main/scala/format/pgn/Reader.scala
+++ b/core/src/main/scala/format/pgn/Reader.scala
@@ -22,9 +22,9 @@ object Reader:
 
   def fullWithSans(pgn: PgnStr, op: Sans => Sans, tags: Tags = Tags.empty): Either[ErrorStr, Result] =
     Parser
-      .full(pgn)
+      .mainline(pgn)
       .map: parsed =>
-        makeReplay(makeGame(parsed.tags ++ tags), op(Sans(parsed.mainline)))
+        makeReplay(makeGame(parsed.tags ++ tags), op(Sans(parsed.sans.map(_.san))))
 
   def fullWithSans(parsed: ParsedPgn, op: Sans => Sans): Result =
     makeReplay(makeGame(parsed.tags), op(Sans(parsed.mainline)))

--- a/core/src/main/scala/format/pgn/parsingModel.scala
+++ b/core/src/main/scala/format/pgn/parsingModel.scala
@@ -11,9 +11,9 @@ import MoveOrDrop.*
 case class PgnNodeData(
     san: San,
     metas: Metas, // describes the position after the move `san` is played
-    /* `variationComments` are comments before the first move of a variation. Example:
+    /** `variationComments` are comments before the first move of a variation. Example:
      * `1.d4 {the best move} ( { on the other hand } 1.e4 { is not as good } )`
-     * => PgnNodeData(1.d4, Metas.empty, List(Node(1.e4, Metas(Comment("is not as good"), List("on the other hand")))
+     * => PgnNodeData(1.d4, Metas.empty, List(Node(1.e4, Metas(Comment("is not as good"), List("on the other hand")))))
      */
     variationComments: List[Comment]
 ):
@@ -37,6 +37,8 @@ type ParsedPgnTree = Node[PgnNodeData]
 
 case class ParsedPgn(initialPosition: InitialComments, tags: Tags, tree: Option[ParsedPgnTree]):
   def mainline: List[San] = tree.fold(List.empty[San])(_.mainline.map(_.value.san))
+  def mainlineWithMetas: List[SanWithMetas] =
+    tree.fold(List.empty[SanWithMetas])(_.mainline.map(x => SanWithMetas(x.value.san, x.value.metas)))
 
   def toPgn: Pgn =
     val sitWithMove = initContext(tags)
@@ -114,5 +116,11 @@ object Sans extends TotalWrapper[Sans, List[San]]
 
 case class Metas(check: Check, checkmate: Boolean, comments: List[Comment], glyphs: Glyphs)
 
+case class ParsedMainline(tags: Tags, sans: List[SanWithMetas])
+
+case class SanWithMetas(san: San, metas: Metas):
+  export metas.*
+  export san.*
+
 object Metas:
-  val empty = Metas(Check.No, checkmate = false, Nil, Glyphs.empty)
+  val empty: Metas = Metas(Check.No, false, Nil, Glyphs.empty)

--- a/core/src/main/scala/format/pgn/parsingModel.scala
+++ b/core/src/main/scala/format/pgn/parsingModel.scala
@@ -2,6 +2,7 @@ package chess
 package format.pgn
 
 import cats.syntax.all.*
+import chess.Situation.AndFullMoveNumber
 import chess.format.Fen
 
 import MoveOrDrop.*
@@ -44,7 +45,7 @@ case class ParsedPgn(initialPosition: InitialComments, tags: Tags, tree: Option[
     val sitWithMove = initContext(tags)
     Pgn(tags, initialPosition, treeToPgn(sitWithMove.situation), sitWithMove.ply.next)
 
-  private def initContext(tags: Tags) =
+  private def initContext(tags: Tags): AndFullMoveNumber =
     val variant = tags.variant | chess.variant.Standard
     def default = Situation.AndFullMoveNumber(Situation(Board.init(variant), White), FullMoveNumber.initial)
 
@@ -57,6 +58,8 @@ case class ParsedPgn(initialPosition: InitialComments, tags: Tags, tree: Option[
       _.mapAccumlOption_(context): (ctx, d) =>
         d.toMove(ctx)
           .fold(ctx -> None)(_ -> _.some)
+
+case class ParsedMainline[A](initialPosition: InitialComments, tags: Tags, sans: List[A])
 
 // Standard Algebraic Notation
 sealed trait San:
@@ -115,8 +118,6 @@ opaque type Sans = List[San]
 object Sans extends TotalWrapper[Sans, List[San]]
 
 case class Metas(check: Check, checkmate: Boolean, comments: List[Comment], glyphs: Glyphs)
-
-case class ParsedMainline[A](tags: Tags, sans: List[A])
 
 case class SanWithMetas(san: San, metas: Metas):
   export metas.*

--- a/core/src/main/scala/format/pgn/parsingModel.scala
+++ b/core/src/main/scala/format/pgn/parsingModel.scala
@@ -116,7 +116,7 @@ object Sans extends TotalWrapper[Sans, List[San]]
 
 case class Metas(check: Check, checkmate: Boolean, comments: List[Comment], glyphs: Glyphs)
 
-case class ParsedMainline(tags: Tags, sans: List[SanWithMetas])
+case class ParsedMainline[A](tags: Tags, sans: List[A])
 
 case class SanWithMetas(san: San, metas: Metas):
   export metas.*

--- a/test-kit/src/test/scala/format/pgn/ParserCheck.scala
+++ b/test-kit/src/test/scala/format/pgn/ParserCheck.scala
@@ -15,9 +15,16 @@ class ParserCheck extends ScalaCheckSuite:
       val result = Parser.full(str).toOption.get.toPgn.render
       assertEquals(result, str)
 
-  test("mainline == full.mainline"):
+  test("mainline == full.mainlineWithMetas"):
     forAll(genPgn(Situation(Standard))): pgn =>
-      val str                                  = pgn.render
-      val expected: Option[List[SanWithMetas]] = Parser.full(str).toOption.map(_.mainlineWithMetas)
-      val mainline: Option[List[SanWithMetas]] = Parser.mainline(str).toOption.map(_.sans)
+      val str      = pgn.render
+      val expected = Parser.full(str).toOption.map(_.mainlineWithMetas)
+      val mainline = Parser.mainlineWithMetas(str).toOption.map(_.sans)
+      assertEquals(mainline, expected)
+
+  test("mainlineWithSan == full.mainline"):
+    forAll(genPgn(Situation(Standard))): pgn =>
+      val str      = pgn.render
+      val expected = Parser.full(str).toOption.map(_.mainline)
+      val mainline = Parser.mainline(str).toOption.map(_.sans)
       assertEquals(mainline, expected)

--- a/test-kit/src/test/scala/format/pgn/ParserCheck.scala
+++ b/test-kit/src/test/scala/format/pgn/ParserCheck.scala
@@ -9,8 +9,15 @@ import ChessTreeArbitraries.*
 
 class ParserCheck extends ScalaCheckSuite:
 
-  test("ParserCheck"):
+  test("parse >>= render == identity"):
     forAll(genPgn(Situation(Standard))): pgn =>
       val str    = pgn.render
       val result = Parser.full(str).toOption.get.toPgn.render
       assertEquals(result, str)
+
+  test("mainline == full.mainline"):
+    forAll(genPgn(Situation(Standard))): pgn =>
+      val str                                  = pgn.render
+      val expected: Option[List[SanWithMetas]] = Parser.full(str).toOption.map(_.mainlineWithMetas)
+      val mainline: Option[List[SanWithMetas]] = Parser.mainline(str).toOption.map(_.sans)
+      assertEquals(mainline, expected)

--- a/test-kit/src/test/scala/format/pgn/ParserTest.scala
+++ b/test-kit/src/test/scala/format/pgn/ParserTest.scala
@@ -16,7 +16,12 @@ class ParserTest extends ChessTest:
   extension (tree: Option[ParsedPgnTree]) def firstMove: PgnNodeData = tree.get.mainline.head.value
   extension (parsed: ParsedPgn) def metas                            = parsed.tree.get.value.metas
 
-  import Parser.{ full as parse, move as parseMove, mainline as parseMainline }
+  import Parser.{
+    full as parse,
+    move as parseMove,
+    mainlineWithMetas as parseMainlineWithMetas,
+    mainline as parseMainline
+  }
 
   test("bom header should be ignored"):
     // "with tags" in:
@@ -151,18 +156,33 @@ class ParserTest extends ChessTest:
       .assertRight: san =>
         assertEquals(san, Std(Square.E4, Pawn))
 
-  test("mainline == full.mainline"):
-    verifyMainlineParser(raws)
-    verifyMainlineParser(shortCastles)
-    verifyMainlineParser(longCastles)
-    verifyMainlineParser(annotatedCastles)
-    verifyMainlineParser(wcc2023)
-    verifyMainlineParser(
+  test("mainlineWithMetas == full.mainlineWithMetas"):
+    verifyMainlineWithMetas(raws)
+    verifyMainlineWithMetas(shortCastles)
+    verifyMainlineWithMetas(longCastles)
+    verifyMainlineWithMetas(annotatedCastles)
+    verifyMainlineWithMetas(wcc2023)
+    verifyMainlineWithMetas(
       List(fromProd1, fromProd2, castleCheck1, castleCheck2, fromCrafty, fromWikipedia, fromTcec)
     )
 
-  def verifyMainlineParser(pgns: List[String]) =
+  def verifyMainlineWithMetas(pgns: List[String]) =
     val expected = pgns.map(PgnStr(_)).traverse(parse).toOption.get.map(_.mainlineWithMetas)
+    val mainline = pgns.map(PgnStr(_)).traverse(parseMainlineWithMetas).toOption.get.map(_.sans)
+    assertEquals(mainline, expected)
+
+  test("mainline == full.mainline"):
+    verifyMainline(raws)
+    verifyMainline(shortCastles)
+    verifyMainline(longCastles)
+    verifyMainline(annotatedCastles)
+    verifyMainline(wcc2023)
+    verifyMainline(
+      List(fromProd1, fromProd2, castleCheck1, castleCheck2, fromCrafty, fromWikipedia, fromTcec)
+    )
+
+  def verifyMainline(pgns: List[String]) =
+    val expected = pgns.map(PgnStr(_)).traverse(parse).toOption.get.map(_.mainline)
     val mainline = pgns.map(PgnStr(_)).traverse(parseMainline).toOption.get.map(_.sans)
     assertEquals(mainline, expected)
 

--- a/test-kit/src/test/scala/format/pgn/ParserTest.scala
+++ b/test-kit/src/test/scala/format/pgn/ParserTest.scala
@@ -152,7 +152,7 @@ class ParserTest extends ChessTest:
   test("sanOnly with nested variations"):
     val sanStr = SanStr("1. e4 (1... e5 (2. Nf3))")
     Parser
-      .sanOnly(sanStr)
+      .san(sanStr)
       .assertRight: san =>
         assertEquals(san, Std(Square.E4, Pawn))
 

--- a/test-kit/src/test/scala/format/pgn/ParserTest.scala
+++ b/test-kit/src/test/scala/format/pgn/ParserTest.scala
@@ -138,6 +138,12 @@ class ParserTest extends ChessTest:
       parse(sans).assertRight: a =>
         assertEquals(a.mainline.size, size)
 
+  test("raws with moves"):
+    raws.foreach: sans =>
+      val result   = Parser.moves(sans.split(' ').toList.map(SanStr(_))).toOption.get
+      val expected = parse(sans).toOption.get.mainline
+      assertEquals(result, expected)
+
   test("mainline == full.mainline"):
     verifyMainlineParser(raws)
     verifyMainlineParser(shortCastles)

--- a/test-kit/src/test/scala/format/pgn/ParserTest.scala
+++ b/test-kit/src/test/scala/format/pgn/ParserTest.scala
@@ -144,6 +144,13 @@ class ParserTest extends ChessTest:
       val expected = parse(sans).toOption.get.mainline
       assertEquals(result, expected)
 
+  test("sanOnly with nested variations"):
+    val sanStr = SanStr("1. e4 (1... e5 (2. Nf3))")
+    Parser
+      .sanOnly(sanStr)
+      .assertRight: san =>
+        assertEquals(san, Std(Square.E4, Pawn))
+
   test("mainline == full.mainline"):
     verifyMainlineParser(raws)
     verifyMainlineParser(shortCastles)


### PR DESCRIPTION
Add two new function to `pgn.Parser`: `mainline` and `mainlineWithMetas`, both are only parse mainline of the input (a.k.a ignoring all variations). Which provides somewhat better performance and leaner data structure for consumers.

This also:
- Adapt `Reader` to use `Parser.mainline`
- Rename `Parser.sanOnly` to `Parser.san` to make it more simple and more fit with the other functions: `full`, `move`, `mainline`.

### benchmark

`mainline` is 20% faster than `full` with mixed pgn inputs:
```
[info] Benchmark                             Mode  Cnt    Score   Error  Units
[info] PgnBench.pgnFullParser               thrpt   45   94.473 ± 0.329  ops/s
[info] PgnBench.pgnMainlineWithMetasParser  thrpt   45  107.413 ± 0.390  ops/s
[info] PgnBench.pgnMainlineParser           thrpt   45  113.836 ± 0.503  ops/s
```

when with `Fixtures.raw`, it's about 8% faster. This is probably a more realistic comparison as for relay we usually receive a list of `SanStr` instead of full pgn.

```diff
-    pgnStrs = Fixtures.gamesForPerfTest ++ Fixtures.wcc2023.map(PgnStr.apply)
+    pgnStrs = Fixtures.raws.map(PgnStr.apply)
```

```
[info] Benchmark                             Mode  Cnt     Score   Error  Units
[info] PgnBench.pgnFullParser               thrpt   45  1886.482 ± 4.410  ops/s
[info] PgnBench.pgnMainlineWithMetasParser  thrpt   45  1909.268 ± 5.395  ops/s
[info] PgnBench.pgnMainlineParser           thrpt   45  2054.838 ± 7.028  ops/s
```