### PR TITLE
Implement pgn.Parser.tags to parse tags

### DIFF
--- a/core/src/main/scala/format/pgn/Parser.scala
+++ b/core/src/main/scala/format/pgn/Parser.scala
@@ -31,6 +31,9 @@ object Parser:
   def mainlineWithMetas(pgn: PgnStr): Either[ErrorStr, ParsedMainline[SanWithMetas]] =
     pgnMainlineParser.parse(pgn.value, "Cannot parse pgn")
 
+  def tags(pgn: PgnStr): Either[ErrorStr, Tags] =
+    tagsParser.parse(pgn.value, "Cannot parse tags").map(Tags(_))
+
   def moves(strMoves: Iterable[SanStr]): Either[ErrorStr, Sans] =
     strMoves.toList.traverse(san).map(Sans(_))
 
@@ -236,6 +239,7 @@ object Parser:
   private inline def escapePgnTag[A](p: P0[A]): P0[A] =
     escape *> P.string("[pgn]").? *> p <* P.string("[/pgn]").? <* escape
 
+  private val tagsParser               = TagParser.tags.surroundedBy(escape)
   private val pgnParser: P0[ParsedPgn] = escapePgnTag(tagsAndMovesParser)
 
   private val pgnMainlineParser: P0[ParsedMainline[SanWithMetas]] =

--- a/test-kit/src/test/scala/format/pgn/ParserTest.scala
+++ b/test-kit/src/test/scala/format/pgn/ParserTest.scala
@@ -181,6 +181,11 @@ class ParserTest extends ChessTest:
       List(fromProd1, fromProd2, castleCheck1, castleCheck2, fromCrafty, fromWikipedia, fromTcec)
     )
 
+  test("tags = full.tags"):
+    val expected = wcc2023.map(PgnStr(_)).traverse(parse).toOption.get.map(_.tags)
+    val tags     = wcc2023.map(PgnStr(_)).traverse(Parser.tags).toOption.get
+    assertEquals(tags, expected)
+
   def verifyMainline(pgns: List[String]) =
     val expected = pgns.map(PgnStr(_)).traverse(parse).toOption.get.map(_.mainline)
     val mainline = pgns.map(PgnStr(_)).traverse(parseMainline).toOption.get.map(_.sans)


### PR DESCRIPTION
Would be useful for this: https://github.com/lichess-org/lila/blob/62137a34043da1e869c38eecf75916d1dbdf7f22/modules/study/src/main/ExplorerGame.scala#L58

As it can be refactored as follow:

```diff
   private def gameTitle(g: Game): String =
-    val pgn = g.pgnImport.flatMap(pgnImport => Parser.full(pgnImport.pgn).toOption)
-    val white =
-      pgn.flatMap(_.tags(_.White)) | namer.playerTextBlocking(g.whitePlayer)(using lightUserApi.sync)
-    val black =
-      pgn.flatMap(_.tags(_.Black)) | namer.playerTextBlocking(g.blackPlayer)(using lightUserApi.sync)
+    val tags = g.pgnImport.flatMap(pgni => Parser.full(pgni.pgn).toOption).map(_.tags).getOrElse(Tags.empty)
+    gameTitle(g, tags)
+
+  private def gameTitle(g: Game, tags: Tags): String =
+    val white  = tags(_.White) | namer.playerTextBlocking(g.whitePlayer)(using lightUserApi.sync)
+    val black  = tags(_.Black) | namer.playerTextBlocking(g.blackPlayer)(using lightUserApi.sync)
     val result = chess.Outcome.showResult(chess.Outcome(g.winnerColor).some)
     val event: Option[String] =
-      (pgn.flatMap(_.tags(_.Event)), pgn.flatMap(_.tags.year).map(_.toString)) match
+      (tags(_.Event), tags.year.map(_.toString)) match
         case (Some(event), Some(year)) if event.contains(year) => event.some
         case (Some(event), Some(year))                         => s"$event, $year".some
         case (eventO, yearO)                                   => eventO.orElse(yearO)
```