### PR TITLE
Improve error messages for `Reader.full` and friends

### DIFF
--- a/core/src/main/scala/format/pgn/Parser.scala
+++ b/core/src/main/scala/format/pgn/Parser.scala
@@ -183,7 +183,9 @@ object Parser:
           Metas(check, checkmate, comments.cleanUp, glyphs)
 
     val standard: P[Std] =
-      P.oneOf((pawn :: disambiguated :: ambigous :: Nil).map(_.backtrack))
+      P.oneOf:
+        (pawn :: disambiguated :: ambigous :: Nil).map:
+          _.backtrack.withString.map((san, raw) => san.copy(rawString = raw.some))
 
     val castleQSide = List("O-O-O", "o-o-o", "0-0-0", "O‑O‑O", "o‑o‑o", "0‑0‑0", "O–O–O", "o–o–o", "0–0–0")
     val qCastle: P[Side] = P.stringIn(castleQSide).as(QueenSide)
@@ -191,7 +193,7 @@ object Parser:
     val castleKSide      = List("O-O", "o-o", "0-0", "O‑O", "o‑o", "0‑0", "O–O", "o–o", "0–0")
     val kCastle: P[Side] = P.stringIn(castleKSide).as(KingSide)
 
-    val castle: P[San] = (qCastle | kCastle).map(Castle(_))
+    val castle: P[San] = (qCastle | kCastle).withString.map((side, raw) => Castle(side, raw.some))
 
     // B@g5
     val pieceDrop: P[Drop] = ((role <* P.char('@')) ~ dest).map(Drop(_, _))
@@ -199,7 +201,9 @@ object Parser:
     val pawnDrop: P[Drop] = (P.char('@') *> dest).map(Drop(Pawn, _))
 
     val drop: P[Drop] =
-      P.oneOf((pieceDrop :: pawnDrop :: Nil).map(_.backtrack))
+      P.oneOf:
+        (pieceDrop :: pawnDrop :: Nil).map:
+          _.backtrack.withString.map((san, raw) => san.copy(rawString = raw.some))
 
     val san: P[San] = (castle | standard | drop).withContext("Invalid chess move")
 

--- a/core/src/main/scala/format/pgn/Reader.scala
+++ b/core/src/main/scala/format/pgn/Reader.scala
@@ -43,10 +43,10 @@ object Reader:
         case Right(replay)     => Result.Complete(replay)
 
   inline def makeError(index: Int, startedPly: Ply, san: San): ErrorStr =
-    val ply    = (startedPly + index).next
+    val ply    = startedPly + index
     val moveAt = ply.fullMoveNumber.value
     val move   = san.rawString.getOrElse(san.toString)
-    ErrorStr(s"Cannot play $move at move $moveAt, ply $ply")
+    ErrorStr(s"Cannot play $move at move $moveAt by ${ply.turn.name}")
 
   private def makeGame(tags: Tags) =
     val g = Game(variantOption = tags.variant, fen = tags.fen)

--- a/core/src/main/scala/format/pgn/Reader.scala
+++ b/core/src/main/scala/format/pgn/Reader.scala
@@ -34,12 +34,19 @@ object Reader:
       .map(moves => makeReplay(makeGame(tags), op(moves)))
 
   private def makeReplay(game: Game, sans: Sans): Result =
-    sans.value
-      .foldM(Replay(game)): (replay, san) =>
-        san(replay.state.situation).bimap((replay, _), replay.addMove(_))
+    sans.value.zipWithIndex
+      .foldM(Replay(game)) { case (replay, (san, index)) =>
+        san(replay.state.situation).bimap(_ => (replay, makeError(index, game.ply, san)), replay.addMove(_))
+      }
       .match
         case Left(replay, err) => Result.Incomplete(replay, err)
         case Right(replay)     => Result.Complete(replay)
+
+  inline def makeError(index: Int, startedPly: Ply, san: San): ErrorStr =
+    val ply    = (startedPly + index).next
+    val moveAt = ply.fullMoveNumber.value
+    val move   = san.rawString.getOrElse(san.toString)
+    ErrorStr(s"Cannot play $move at move $moveAt, ply $ply")
 
   private def makeGame(tags: Tags) =
     val g = Game(variantOption = tags.variant, fen = tags.fen)

--- a/core/src/main/scala/format/pgn/parsingModel.scala
+++ b/core/src/main/scala/format/pgn/parsingModel.scala
@@ -64,6 +64,7 @@ case class ParsedMainline[A](initialPosition: InitialComments, tags: Tags, sans:
 // Standard Algebraic Notation
 sealed trait San:
   def apply(situation: Situation): Either[ErrorStr, MoveOrDrop]
+  def rawString: Option[String] = None
 
 case class Std(
     dest: Square,
@@ -71,7 +72,8 @@ case class Std(
     capture: Boolean = false,
     file: Option[File] = None,
     rank: Option[Rank] = None,
-    promotion: Option[PromotableRole] = None
+    promotion: Option[PromotableRole] = None,
+    override val rawString: Option[String] = None
 ) extends San:
 
   def apply(situation: Situation): Either[ErrorStr, chess.Move] =
@@ -88,12 +90,12 @@ case class Std(
 
   private inline def compare[A](a: Option[A], b: A) = a.fold(true)(b ==)
 
-case class Drop(role: Role, square: Square) extends San:
+case class Drop(role: Role, square: Square, override val rawString: Option[String] = None) extends San:
 
   def apply(situation: Situation): Either[ErrorStr, chess.Drop] =
     situation.drop(role, square)
 
-case class Castle(side: Side) extends San:
+case class Castle(side: Side, override val rawString: Option[String] = None) extends San:
 
   def apply(situation: Situation): Either[ErrorStr, chess.Move] =
 

--- a/test-kit/src/test/scala/format/pgn/ParserTest.scala
+++ b/test-kit/src/test/scala/format/pgn/ParserTest.scala
@@ -49,7 +49,7 @@ class ParserTest extends ChessTest:
   test("promotion check as a queen"):
     parse("b8=Q ").assertRight: parsed =>
       parsed.mainline.headOption.assertSome: san =>
-        assertEquals(san, Std(Square.B8, Pawn, promotion = Option(Queen)))
+        assertEquals(san, Std(Square.B8, Pawn, promotion = Option(Queen), rawString = "b8=Q".some))
 
   test("promotion check as a rook"):
     parse("b8=R ").assertRight: parsed =>
@@ -88,24 +88,27 @@ class ParserTest extends ChessTest:
   test("glyphs"):
 
     parseMove("b8=B ").assertRight: node =>
-      assertEquals(node.value.san, Std(Square.B8, Pawn, promotion = Option(Bishop)))
+      assertEquals(node.value.san, Std(Square.B8, Pawn, promotion = Option(Bishop), rawString = "b8=B".some))
 
     parseMove("1. e4").assertRight: node =>
-      assertEquals(node.value.san, Std(Square.E4, Pawn))
+      assertEquals(node.value.san, Std(Square.E4, Pawn, rawString = "e4".some))
 
     parseMove("e4").assertRight: node =>
-      assertEquals(node.value.san, Std(Square.E4, Pawn))
+      assertEquals(node.value.san, Std(Square.E4, Pawn, rawString = "e4".some))
 
     parseMove("e4!").assertRight: node =>
-      assertEquals(node.value.san, Std(Square.E4, Pawn))
+      assertEquals(node.value.san, Std(Square.E4, Pawn, rawString = "e4".some))
       assertEquals(node.value.metas.glyphs, Glyphs(Glyph.MoveAssessment.good.some, None, Nil))
 
     parseMove("Ne7g6+?!").assertRight: node =>
-      assertEquals(node.value.san, Std(Square.G6, Knight, false, Some(File.E), Some(Rank.Seventh)))
+      assertEquals(
+        node.value.san,
+        Std(Square.G6, Knight, false, Some(File.E), Some(Rank.Seventh), rawString = "Ne7g6".some)
+      )
       assertEquals(node.value.metas.glyphs, Glyphs(Glyph.MoveAssessment.dubious.some, None, Nil))
 
     parseMove("P@e4?!").assertRight: node =>
-      assertEquals(node.value.san, Drop(Pawn, Square.E4))
+      assertEquals(node.value.san, Drop(Pawn, Square.E4, rawString = "P@e4".some))
       assertEquals(node.value.metas.glyphs, Glyphs(Glyph.MoveAssessment.dubious.some, None, Nil))
 
   test("nags"):
@@ -154,7 +157,7 @@ class ParserTest extends ChessTest:
     Parser
       .san(sanStr)
       .assertRight: san =>
-        assertEquals(san, Std(Square.E4, Pawn))
+        assertEquals(san, Std(Square.E4, Pawn, rawString = "e4".some))
 
   test("mainlineWithMetas == full.mainlineWithMetas"):
     verifyMainlineWithMetas(raws)

--- a/test-kit/src/test/scala/format/pgn/ReaderTest.scala
+++ b/test-kit/src/test/scala/format/pgn/ReaderTest.scala
@@ -156,14 +156,14 @@ class ReaderTest extends ChessTest:
       .full(pgn)
       .assertRight:
         case Incomplete(replay, error) =>
-          assertEquals(error, ErrorStr("Cannot play e6 at move 1, ply 1"))
+          assertEquals(error, ErrorStr("Cannot play e6 at move 1 by white"))
 
   test("more complicated error message"):
     val pgn = PgnStr(
-      "e3 Nc6 d4 Nf6 c3 e5 dxe5 Nxe5 Bb5 a6 Ba4 b5 Bb3 d5 e4 dxe4 f4 Qxd1+ Kxd1 Nd3 Be3 Ng4 Bd4 Ngf2+ Bxf2 Nxf2+ Ke1 Nxh1 Bd5 Ra7 Bc6+ Kd8 Bxe4 Bd6 g3 Re8 Nd2 f5 Ne2 fxe4 Kf1 e3 Kg2 exd2 Rxh1 Bb7+ Kf2 Bc5+ Kf3 d1=Q#"
+      "e3 Nc6 d4 Nf6 c3 e5 dxe5 Nxe5 Bb5 a6 Ba4 b5 Bb3 d5 e4 dxe4 f4 Qxd1+ Kxd1 Nd3 Be3 Ng4 Bd4 Ngf2+ Bxf2 Nxf2+ Ke1 Nxh1 Bd5 Ra7 Bc6+ Kd8 Bxe4 Bd6 g3 Re8 Nd2 f5 Ne2 fxe4 Kf1 e3 Kg2 exd2 Rxh1 Bb7+ Kf2 Bg3+ Kf3 d1=Q#"
     )
     Reader
       .full(pgn)
       .assertRight:
         case Incomplete(replay, error) =>
-          assertEquals(error, ErrorStr("Cannot play Kf3 at move 25, ply 49"))
+          assertEquals(error, ErrorStr("Cannot play Bg3 at move 24 by black"))

--- a/test-kit/src/test/scala/format/pgn/ReaderTest.scala
+++ b/test-kit/src/test/scala/format/pgn/ReaderTest.scala
@@ -147,3 +147,23 @@ class ReaderTest extends ChessTest:
             .lift(42)
             .assertSome: m =>
               assertEquals(m.toUci.uci, "e7f8q")
+
+  /*============== Error Messages ==============*/
+
+  test("simple error message"):
+    val pgn = PgnStr("1.e6")
+    Reader
+      .full(pgn)
+      .assertRight:
+        case Incomplete(replay, error) =>
+          assertEquals(error, ErrorStr("Cannot play e6 at move 1, ply 1"))
+
+  test("more complicated error message"):
+    val pgn = PgnStr(
+      "e3 Nc6 d4 Nf6 c3 e5 dxe5 Nxe5 Bb5 a6 Ba4 b5 Bb3 d5 e4 dxe4 f4 Qxd1+ Kxd1 Nd3 Be3 Ng4 Bd4 Ngf2+ Bxf2 Nxf2+ Ke1 Nxh1 Bd5 Ra7 Bc6+ Kd8 Bxe4 Bd6 g3 Re8 Nd2 f5 Ne2 fxe4 Kf1 e3 Kg2 exd2 Rxh1 Bb7+ Kf2 Bc5+ Kf3 d1=Q#"
+    )
+    Reader
+      .full(pgn)
+      .assertRight:
+        case Incomplete(replay, error) =>
+          assertEquals(error, ErrorStr("Cannot play Kf3 at move 25, ply 49"))


### PR DESCRIPTION
This include some changes on `pgn.Parser` to include the raw value of `San` in it's ADT, which is needed for us to return better error messages. This also matches `chessops` library's error messages.

here are two examples:

pgn:

```
1. e6
```

```diff
- Cannot play Pawn e6
+ Cannot play e6 at move 1 by White
```

pgn:

```
e3 Nc6 d4 Nf6 c3 e5 dxe5 Nxe5 Bb5 a6 Ba4 b5 Bb3 d5 e4 dxe4 f4 Qxd1+ Kxd1 Nd3 Be3 Ng4 Bd4 Ngf2+ Bxf2 Nxf2+ Ke1 Nxh1 Bd5 Ra7 Bc6+ Kd8 Bxe4 Bd6 g3 Re8 Nd2 f5 Ne2 fxe4 Kf1 e3 Kg2 exd2 Rxh1 Bb7+ Kf2 Bc5+ Kf3 d1=Q#
```

```diff
- Cannot play King f3
+ Cannot play Kf3 at move 25 by black
```
