### PR TITLE
Make `Reader.Result` a case class

### DIFF
--- a/core/src/main/scala/format/pgn/Reader.scala
+++ b/core/src/main/scala/format/pgn/Reader.scala
@@ -10,15 +10,13 @@ object Reader:
       failure.fold(replay.asRight)(_.asLeft)
 
   def full(pgn: PgnStr, tags: Tags = Tags.empty): Either[ErrorStr, Result] =
-    fullWithSans(pgn, identity, tags)
+    Parser.mainline(pgn).map(fullWithSans)
 
   def moves(sans: Iterable[SanStr], tags: Tags): Either[ErrorStr, Result] =
     movesWithSans(sans, identity, tags)
 
-  def fullWithSans(pgn: PgnStr, op: Sans => Sans, tags: Tags = Tags.empty): Either[ErrorStr, Result] =
-    Parser
-      .mainline(pgn)
-      .map(parsed => makeReplay(makeGame(parsed.tags ++ tags), op(Sans(parsed.sans))))
+  def fullWithSans(parsed: ParsedMainline[San]): Result =
+    makeReplay(makeGame(parsed.tags), Sans(parsed.sans))
 
   def fullWithSans(parsed: ParsedPgn, op: Sans => Sans): Result =
     makeReplay(makeGame(parsed.tags), op(Sans(parsed.mainline)))

--- a/test-kit/src/test/scala/AntichessVariantTest.scala
+++ b/test-kit/src/test/scala/AntichessVariantTest.scala
@@ -211,7 +211,7 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
     Reader
       .full(fullGame)
       .assertRight:
-        case Reader.Result.Complete(replay) =>
+        case Reader.Result(replay, None) =>
           val game = replay.state
           assert(game.situation.end)
           // In antichess, the player who has just lost all their pieces is the winner
@@ -256,7 +256,7 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
     Reader
       .full(pgn)
       .assertRight:
-        case Reader.Result.Complete(replay) =>
+        case Reader.Result(replay, None) =>
           val game = replay.state
           assertNot(game.situation.end)
           assertEquals(game.situation.winner, None)

--- a/test-kit/src/test/scala/Chess960Test.scala
+++ b/test-kit/src/test/scala/Chess960Test.scala
@@ -36,7 +36,7 @@ class Chess960Test extends ChessTest:
     Reader
       .full(pgn)
       .assertRight:
-        case Reader.Result.Complete(replay) =>
+        case Reader.Result(replay, None) =>
           assertEquals(
             replay.state.situation.legalMoves.find(_.castles).map(_.toUci),
             Some(format.Uci.Move(Square.E1, Square.B1))

--- a/test-kit/src/test/scala/DividerTest.scala
+++ b/test-kit/src/test/scala/DividerTest.scala
@@ -8,8 +8,8 @@ class DividerTest extends ChessTest:
 
   def makeReplay(moves: String) =
     format.pgn.Reader.full(moves).get match
-      case format.pgn.Reader.Result.Complete(replay) => replay.chronoMoves.map(_.fold(_.before, _.before))
-      case x                                         => sys.error(s"Unexpected incomplete replay $x")
+      case format.pgn.Reader.Result(replay, None) => replay.chronoMoves.map(_.fold(_.before, _.before))
+      case x                                      => sys.error(s"Unexpected incomplete replay $x")
 
   test("the divider finds middlegame and endgame: game1"):
     // http://l.org/KrTnOvuD

--- a/test-kit/src/test/scala/format/pgn/ReaderTest.scala
+++ b/test-kit/src/test/scala/format/pgn/ReaderTest.scala
@@ -8,7 +8,7 @@ import MoveOrDrop.*
 class ReaderTest extends ChessTest:
 
   import Fixtures.*
-  import Reader.Result.*
+  import Reader.*
 
   // "only raw moves" should:
   test("many games"):
@@ -16,7 +16,7 @@ class ReaderTest extends ChessTest:
       Reader
         .full(c)
         .assertRight:
-          case Complete(replay) => assertEquals(replay.moves.size, c.split(' ').length)
+          case Result(replay, None) => assertEquals(replay.moves.size, c.split(' ').length)
   test("example from prod 1"):
     assert(Reader.full(fromProd1).isRight)
   test("example from prod 2"):
@@ -31,12 +31,12 @@ class ReaderTest extends ChessTest:
     Reader
       .full(withDelimiters)
       .assertRight:
-        case Complete(replay) => assertEquals(replay.moves.size, 33)
+        case Result(replay, None) => assertEquals(replay.moves.size, 33)
   test("and delimiters on new lines"):
     Reader
       .full(withDelimitersOnNewLines)
       .assertRight:
-        case Complete(replay) => assertEquals(replay.moves.size, 33)
+        case Result(replay, None) => assertEquals(replay.moves.size, 33)
   // "tags and moves" should:
   test("chess960"):
     assert(Reader.full(complete960).isRight)
@@ -64,13 +64,13 @@ class ReaderTest extends ChessTest:
     Reader
       .full(invalidVariant)
       .assertRight:
-        case Complete(replay) =>
+        case Result(replay, None) =>
           assertEquals(replay.setup.board.variant, variant.Standard)
   test("promoting to a rook"):
     Reader
       .full(fromLichessBadPromotion)
       .assertRight:
-        case Complete(replay) =>
+        case Result(replay, None) =>
           replay.chronoMoves
             .lift(10)
             .assertSome: m =>
@@ -87,7 +87,7 @@ class ReaderTest extends ChessTest:
     Reader
       .full(crazyhouse1)
       .assertRight:
-        case Complete(replay) =>
+        case Result(replay, None) =>
           replay.chronoMoves
             .lift(11)
             .assertSome: m =>
@@ -96,12 +96,12 @@ class ReaderTest extends ChessTest:
     Reader
       .full(crazyhouse2)
       .assertRight:
-        case Complete(replay) => assertEquals(replay.chronoMoves.size, 111)
+        case Result(replay, None) => assertEquals(replay.chronoMoves.size, 111)
   test("crazyhouse without variant tag"):
     Reader
       .full(crazyhouseNoVariantTag)
       .assertRight:
-        case Incomplete(replay, _) =>
+        case Result(replay, _) =>
           assertEquals(replay.chronoMoves.size, 8)
   test("crazyhouse from chess.com"):
     assert(Reader.full(chessComCrazyhouse).isRight)
@@ -111,38 +111,38 @@ class ReaderTest extends ChessTest:
     Reader
       .full(fromPosProdCloseChess)
       .assertRight:
-        case Complete(replay) =>
+        case Result(replay, None) =>
           assertEquals(replay.chronoMoves.size, 152)
   test("from position empty FEN"):
     Reader
       .full(fromPositionEmptyFen)
       .assertRight:
-        case Complete(replay) =>
+        case Result(replay, None) =>
           assertEquals(replay.chronoMoves.size, 164)
   test("preserves initial ply"):
     Reader
       .full(caissa)
       .assertRight:
-        case Complete(replay) =>
+        case Result(replay, None) =>
           assertEquals(replay.setup.startedAtPly, 43)
 
   test("partial from broadcast"):
     Reader
       .full(festivalFigueira)
       .assertRight:
-        case Incomplete(replay, _) =>
+        case Result(replay, _) =>
           assertEquals(replay.chronoMoves.size, 113)
   test("invisible char"):
     Reader
       .full(invisibleChar)
       .assertRight:
-        case Complete(replay) =>
+        case Result(replay, None) =>
           assertEquals(replay.chronoMoves.size, 19)
   test("exotic notation from clono.no"):
     Reader
       .full(clonoNoExoticNotation)
       .assertRight:
-        case Complete(replay) =>
+        case Result(replay, None) =>
           replay.chronoMoves
             .lift(42)
             .assertSome: m =>
@@ -155,7 +155,7 @@ class ReaderTest extends ChessTest:
     Reader
       .full(pgn)
       .assertRight:
-        case Incomplete(replay, error) =>
+        case Result(replay, Some(error)) =>
           assertEquals(error, ErrorStr("Cannot play e6 at move 1 by white"))
 
   test("error message by black"):
@@ -163,7 +163,7 @@ class ReaderTest extends ChessTest:
     Reader
       .full(pgn)
       .assertRight:
-        case Incomplete(replay, error) =>
+        case Result(replay, Some(error)) =>
           assertEquals(error, ErrorStr("Cannot play e4 at move 1 by black"))
 
   test("more error message"):
@@ -173,5 +173,5 @@ class ReaderTest extends ChessTest:
     Reader
       .full(pgn)
       .assertRight:
-        case Incomplete(replay, error) =>
+        case Result(replay, Some(error)) =>
           assertEquals(error, ErrorStr("Cannot play Bg3 at move 24 by black"))


### PR DESCRIPTION
In `lila`, We only use `Complete/Incomplete` in `parseImport` https://github.com/lichess-org/lila/blob/dccd3486519f191818685d9b5d6c4b4125e86118/modules/tree/src/main/ParseImport.scala#L29-L32 which in turn doesn't care that much about `Complete/Incomplete` case either.

The changes need to make in `lila` is pretty minimal:

```diff
-          .pipe:
-            case Reader.Result.Complete(replay)          => (replay, none[ErrorStr])
-            case Reader.Result.Incomplete(replay, error) => (replay, error.some)
-          .pipe { (replay, relayError) =>
+          .pipe { case Reader.Result(replay, relayError) =>
```

This is my effort to reconcile two concepts: `Replay` and `Reader`. I believe they should become one.