### PR TITLE
 Remove Variant.applyVariantEffect and friends

### DIFF
--- a/core/src/main/scala/MoveOrDrop.scala
+++ b/core/src/main/scala/MoveOrDrop.scala
@@ -16,8 +16,6 @@ sealed trait MoveOrDrop:
 
   def color: Color
 
-  def applyVariantEffect: MoveOrDrop
-
   def finalizeAfter: Board
 
   def situationBefore: Situation
@@ -118,8 +116,6 @@ case class Move(
       h.copy(positionHashes = PositionHash(Hash(Situation(board, !piece.color))).combine(basePositionHashes))
     }
 
-  def applyVariantEffect: Move = before.variant.addVariantEffect(this)
-
   // does this move capture an opponent piece?
   inline def captures = capture.isDefined
 
@@ -193,8 +189,6 @@ case class Drop(
     }
 
   inline def withHistory(inline h: History) = copy(after = after.withHistory(h))
-
-  def applyVariantEffect: Drop = this
 
   def afterWithLastMove: Board =
     after.variant.finalizeBoard(

--- a/core/src/main/scala/Replay.scala
+++ b/core/src/main/scala/Replay.scala
@@ -12,7 +12,7 @@ case class Replay(setup: Game, moves: List[MoveOrDrop], state: Game):
 
   def addMove(moveOrDrop: MoveOrDrop): Replay =
     copy(
-      moves = moveOrDrop.applyVariantEffect :: moves,
+      moves = moveOrDrop :: moves,
       state = moveOrDrop.applyGame(state)
     )
 

--- a/core/src/main/scala/Situation.scala
+++ b/core/src/main/scala/Situation.scala
@@ -2,7 +2,7 @@ package chess
 
 import cats.syntax.all.*
 import chess.format.Uci
-import chess.variant.{ Antichess, Crazyhouse, Standard }
+import chess.variant.{ Antichess, Atomic, Crazyhouse, Standard }
 
 import bitboard.Bitboard
 import bitboard.Bitboard.*
@@ -102,7 +102,9 @@ case class Situation(board: Board, color: Color):
             case Queen  => genQueen(us & bb, targets)
             case King   => genKingAt(targets, square)
       }
-      variant.applyVariantEffect(moves).filter(variant.kingSafety)
+
+      if variant.atomic then moves.map(Atomic.explodeSurroundingPieces).filter(variant.kingSafety)
+      else moves.filter(variant.kingSafety)
 
     // in antichess, if there are capture moves, only capture moves are allowed
     // so, we have to find all captures first,

--- a/core/src/main/scala/format/pgn/parsingModel.scala
+++ b/core/src/main/scala/format/pgn/parsingModel.scala
@@ -102,8 +102,7 @@ case class Castle(side: Side, override val rawString: Option[String] = None) ext
     else
       ourKing
         .flatMap: k =>
-          variant
-            .applyVariantEffect(genCastling(k))
+          genCastling(k)
             .filter(variant.kingSafety)
             .find(_.castle.exists(_.side == side))
         .toRight(ErrorStr(s"Cannot castle ${side.fold("kingside", "queenside")}"))

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -120,19 +120,6 @@ abstract class Variant private[variant] (
   def opponentHasInsufficientMaterial(situation: Situation) =
     InsufficientMatingMaterial(situation.board, !situation.color)
 
-  // Some variants have an extra effect on the board on a move. For example, in Atomic, some
-  // pieces surrounding a capture explode
-  def hasMoveEffects = false
-
-  /** Applies a variant specific effect to the move. This helps decide whether a king is endangered by a move, for
-    * example
-    */
-  def addVariantEffect(move: Move): Move = move
-
-  // TODO remove this implementation
-  def applyVariantEffect(moves: List[Move]): List[Move] =
-    if hasMoveEffects then moves.map(addVariantEffect) else moves
-
   def fiftyMoves(history: History): Boolean = history.halfMoveClock >= HalfMoveClock(100)
 
   def isIrreversible(move: Move): Boolean =


### PR DESCRIPTION
Each variant needs to take care of it's own effect and do it when generating moves. This leads to simpler Variant trait, and also the whole code base as the other places don't need to know about effect anymore.