### PR TITLE
re-organize chess's classes

### DIFF
--- a/bench/src/main/scala/benchmarks/BinaryFenBench.scala
+++ b/bench/src/main/scala/benchmarks/BinaryFenBench.scala
@@ -5,7 +5,7 @@ import org.openjdk.jmh.infra.Blackhole
 import java.util.concurrent.TimeUnit
 
 import cats.syntax.all.*
-import chess.{ FullMoveNumber, Board }
+import chess.{ FullMoveNumber, Position }
 import chess.variant.Chess960
 import chess.{ Mode as _, * }
 import chess.format.{ Fen, FullFen, BinaryFen }
@@ -24,20 +24,20 @@ class BinaryFenBench:
   private val Work: Long = 10
 
   @Param(Array("10", "100", "1000"))
-  var games: Int                          = scala.compiletime.uninitialized
-  var sits: List[Board.AndFullMoveNumber] = scala.compiletime.uninitialized
-  var fens: List[BinaryFen]               = scala.compiletime.uninitialized
+  var games: Int                             = scala.compiletime.uninitialized
+  var sits: List[Position.AndFullMoveNumber] = scala.compiletime.uninitialized
+  var fens: List[BinaryFen]                  = scala.compiletime.uninitialized
 
   @Setup
   def setup(): Unit =
     sits = makeBoards(Perft.randomPerfts, games)
     fens = sits.map(BinaryFen.write)
 
-  private def makeBoards(perfts: List[Perft], games: Int): List[Board.AndFullMoveNumber] =
+  private def makeBoards(perfts: List[Perft], games: Int): List[Position.AndFullMoveNumber] =
     perfts
       .take(games)
       .flatMap(x => Fen.read(Chess960, x.epd))
-      .map(Board.AndFullMoveNumber(_, FullMoveNumber(1)))
+      .map(Position.AndFullMoveNumber(_, FullMoveNumber(1)))
 
   @Benchmark
   def write(bh: Blackhole) =

--- a/bench/src/main/scala/benchmarks/DestinationsBench.scala
+++ b/bench/src/main/scala/benchmarks/DestinationsBench.scala
@@ -7,7 +7,7 @@ import org.openjdk.jmh.infra.Blackhole
 import chess.format.*
 import chess.perft.Perft
 import chess.variant.*
-import chess.Board
+import chess.Position
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -23,14 +23,14 @@ class DestinationsBench:
   @Param(Array("100"))
   var games: Int = scala.compiletime.uninitialized
 
-  var threecheckInput: List[Board]  = scala.compiletime.uninitialized
-  var antichessInput: List[Board]   = scala.compiletime.uninitialized
-  var atomicInput: List[Board]      = scala.compiletime.uninitialized
-  var crazyhouseInput: List[Board]  = scala.compiletime.uninitialized
-  var racingkingsInput: List[Board] = scala.compiletime.uninitialized
-  var hordeInput: List[Board]       = scala.compiletime.uninitialized
-  var randomInput: List[Board]      = scala.compiletime.uninitialized
-  var trickyInput: List[Board]      = scala.compiletime.uninitialized
+  var threecheckInput: List[Position]  = scala.compiletime.uninitialized
+  var antichessInput: List[Position]   = scala.compiletime.uninitialized
+  var atomicInput: List[Position]      = scala.compiletime.uninitialized
+  var crazyhouseInput: List[Position]  = scala.compiletime.uninitialized
+  var racingkingsInput: List[Position] = scala.compiletime.uninitialized
+  var hordeInput: List[Position]       = scala.compiletime.uninitialized
+  var randomInput: List[Position]      = scala.compiletime.uninitialized
+  var trickyInput: List[Position]      = scala.compiletime.uninitialized
 
   @Setup
   def setup(): Unit =
@@ -75,13 +75,13 @@ class DestinationsBench:
   def tricky(bh: Blackhole) =
     bench(trickyInput)(bh)
 
-  private def bench(sits: List[Board])(bh: Blackhole) =
+  private def bench(sits: List[Position])(bh: Blackhole) =
     val x = sits.map: x =>
       Blackhole.consumeCPU(Work)
       x.destinations
     bh.consume(x)
 
-  private def makeBoards(perfts: List[Perft], variant: Variant, games: Int): List[Board] =
+  private def makeBoards(perfts: List[Perft], variant: Variant, games: Int): List[Position] =
     perfts
       .take(games)
       .map(p => Fen.read(variant, p.epd).getOrElse(throw RuntimeException("boooo")))

--- a/bench/src/main/scala/benchmarks/HashBench.scala
+++ b/bench/src/main/scala/benchmarks/HashBench.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 
 import cats.syntax.all.*
 import chess.format.pgn.{ Fixtures, Reader }
-import chess.{ Board, Hash }
+import chess.{ Position, Hash }
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -20,7 +20,7 @@ class HashBench:
   // the unit of CPU work per iteration
   private val Work: Long = 10
 
-  var boards: List[Board] = scala.compiletime.uninitialized
+  var boards: List[Position] = scala.compiletime.uninitialized
 
   @Setup
   def setup() =

--- a/bench/src/main/scala/benchmarks/PlayBench.scala
+++ b/bench/src/main/scala/benchmarks/PlayBench.scala
@@ -22,9 +22,9 @@ class PlayBench:
   // the unit of CPU work per iteration
   private val Work: Long = 10
 
-  var dividerGames: List[List[Board]] = scala.compiletime.uninitialized
-  var gameMoves: List[List[SanStr]]   = scala.compiletime.uninitialized
-  var standard: Game                  = scala.compiletime.uninitialized
+  var dividerGames: List[List[Position]] = scala.compiletime.uninitialized
+  var gameMoves: List[List[SanStr]]      = scala.compiletime.uninitialized
+  var standard: Game                     = scala.compiletime.uninitialized
 
   def gameReplay(sans: String) =
     Replay.boards(SanStr.from(sans.split(' ')), None, Standard).toOption.get
@@ -37,7 +37,7 @@ class PlayBench:
     var games = Fixtures.prod500standard
     gameMoves = games.take(nb).map(g => SanStr.from(g.split(' ').toList))
 
-    standard = Game(Board.init(chess.variant.Standard, White))
+    standard = Game(Position.init(chess.variant.Standard, White))
 
   @Benchmark
   def divider(bh: Blackhole) =

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 inThisBuild(
   Seq(
     scalaVersion      := "3.6.4",
-    version           := "17.5.0-RC1",
+    version           := "17.5.0-RC4",
     organization      := "org.lichess",
     licenses += ("MIT" -> url("https://opensource.org/licenses/MIT")),
     publishTo         := Option(Resolver.file("file", new File(sys.props.getOrElse("publishTo", "")))),

--- a/core/src/main/scala/Bitboard.scala
+++ b/core/src/main/scala/Bitboard.scala
@@ -1,11 +1,11 @@
 package chess
-package bitboard
 
 import scala.annotation.targetName
 
 opaque type Bitboard = Long
 object Bitboard:
-  import Attacks.*
+  import bitboard.Attacks.*
+  import bitboard.Magic
 
   inline def apply(inline l: Long): Bitboard              = l
   inline def apply(inline xs: Iterable[Square]): Bitboard = xs.foldLeft(empty)((b, s) => b | s.bl)

--- a/core/src/main/scala/Bitboard.scala
+++ b/core/src/main/scala/Bitboard.scala
@@ -2,10 +2,10 @@ package chess
 
 import scala.annotation.targetName
 
+import bitboard.Attacks.*
+
 opaque type Bitboard = Long
 object Bitboard:
-  import bitboard.Attacks.*
-  import bitboard.Magic
 
   inline def apply(inline l: Long): Bitboard              = l
   inline def apply(inline xs: Iterable[Square]): Bitboard = xs.foldLeft(empty)((b, s) => b | s.bl)
@@ -30,24 +30,6 @@ object Bitboard:
 
   def aligned(a: Square, b: Square, c: Square): Boolean = ray(a, b).contains(c)
   def between(a: Square, b: Square): Bitboard           = BETWEEN(a.value)(b.value)
-
-  extension (s: Square)
-
-    def bishopAttacks(occupied: Bitboard): Bitboard =
-      ATTACKS(Magic.BISHOP(s.value).bishopIndex(occupied))
-
-    def rookAttacks(occupied: Bitboard): Bitboard =
-      ATTACKS(Magic.ROOK(s.value).rookIndex(occupied))
-
-    def queenAttacks(occupied: Bitboard): Bitboard =
-      bishopAttacks(occupied) ^ rookAttacks(occupied)
-
-    def pawnAttacks(color: Color): Bitboard =
-      color.fold(WHITE_PAWN_ATTACKS(s.value), BLACK_PAWN_ATTACKS(s.value))
-
-    def kingAttacks: Bitboard = KING_ATTACKS(s.value)
-
-    def knightAttacks: Bitboard = KNIGHT_ATTACKS(s.value)
 
   extension (l: Long)
     private def lsb: Square = Square.unsafe(java.lang.Long.numberOfTrailingZeros(l))

--- a/core/src/main/scala/Board.scala
+++ b/core/src/main/scala/Board.scala
@@ -2,8 +2,7 @@ package chess
 
 import cats.syntax.all.*
 
-import chess.bitboard.Bitboard.*
-import chess.bitboard.Bitboard
+import chess.Bitboard.*
 
 // Chess board representation
 case class Board(occupied: Bitboard, byColor: ByColor[Bitboard], byRole: ByRole[Bitboard]):

--- a/core/src/main/scala/Board.scala
+++ b/core/src/main/scala/Board.scala
@@ -1,9 +1,9 @@
 package chess
-package bitboard
 
 import cats.syntax.all.*
 
-import Bitboard.*
+import chess.bitboard.Bitboard.*
+import chess.bitboard.Bitboard
 
 // Chess board representation
 case class Board(occupied: Bitboard, byColor: ByColor[Bitboard], byRole: ByRole[Bitboard]):

--- a/core/src/main/scala/Board.scala
+++ b/core/src/main/scala/Board.scala
@@ -1,7 +1,6 @@
 package chess
 
 import cats.syntax.all.*
-
 import chess.Bitboard.*
 
 // Chess board representation

--- a/core/src/main/scala/Castles.scala
+++ b/core/src/main/scala/Castles.scala
@@ -2,7 +2,6 @@ package chess
 
 import scala.annotation.targetName
 
-import bitboard.Bitboard
 import Square.*
 
 opaque type Castles = Long

--- a/core/src/main/scala/Divider.scala
+++ b/core/src/main/scala/Divider.scala
@@ -20,9 +20,9 @@ object Division:
 
 object Divider:
 
-  def apply(boards: List[Board]): Division =
+  def apply(boards: List[Position]): Division =
 
-    val indexedBoards: List[(Board, Int)] = boards.zipWithIndex
+    val indexedBoards: List[(Position, Int)] = boards.zipWithIndex
 
     val midGame = indexedBoards.collectFirst:
       case (board, index)
@@ -43,11 +43,11 @@ object Divider:
       Ply(boards.size)
     )
 
-  private def majorsAndMinors(board: Board): Int =
+  private def majorsAndMinors(board: Position): Int =
     (board.occupied & ~(board.kings | board.pawns)).count
 
   // Sparse back-rank indicates that pieces have been developed
-  private def backrankSparse(board: Board): Boolean =
+  private def backrankSparse(board: Position): Boolean =
     (Bitboard.firstRank & board.white).count < 4 ||
       (Bitboard.lastRank & board.black).count < 4
 
@@ -85,7 +85,7 @@ object Divider:
     yield (smallSquare << (x + 8 * y), y + 1)
   }.toList
 
-  private def mixedness(board: Board): Int =
+  private def mixedness(board: Position): Int =
     mixednessRegions.foldLeft(0):
       case (acc, (region, y)) =>
         acc + board.byColor.mapReduce(c => (c & region).count)(score(y))

--- a/core/src/main/scala/Divider.scala
+++ b/core/src/main/scala/Divider.scala
@@ -4,8 +4,6 @@ import cats.syntax.all.*
 
 import scala.annotation.switch
 
-import bitboard.Bitboard
-
 case class Division(middle: Option[Ply], end: Option[Ply], plies: Ply):
 
   def openingSize: Ply        = middle | plies

--- a/core/src/main/scala/File.scala
+++ b/core/src/main/scala/File.scala
@@ -1,7 +1,5 @@
 package chess
 
-import chess.bitboard.Bitboard
-
 opaque type File = Int
 object File:
 

--- a/core/src/main/scala/Game.scala
+++ b/core/src/main/scala/Game.scala
@@ -4,7 +4,7 @@ import chess.format.pgn.SanStr
 import chess.format.{ Fen, Uci, pgn }
 
 case class Game(
-    board: Board,
+    board: Position,
     sans: Vector[SanStr] = Vector(),
     clock: Option[Clock] = None,
     ply: Ply = Ply.initial, // plies
@@ -83,9 +83,9 @@ case class Game(
 
   inline def fullMoveNumber: FullMoveNumber = ply.fullMoveNumber
 
-  inline def withBoard(inline b: Board): Game = copy(board = b)
+  inline def withBoard(inline b: Position): Game = copy(board = b)
 
-  inline def updateBoard(inline f: Board => Board): Game = withBoard(f(board))
+  inline def updateBoard(inline f: Position => Position): Game = withBoard(f(board))
 
   inline def withPlayer(c: Color): Game = copy(board = board.copy(color = c))
 
@@ -94,7 +94,7 @@ case class Game(
 object Game:
 
   def apply(variant: chess.variant.Variant): Game =
-    Game(Board.init(variant, White))
+    Game(Position.init(variant, White))
 
   def apply(variantOption: Option[chess.variant.Variant], fen: Option[Fen.Full]): Game =
     val variant = variantOption | chess.variant.Standard

--- a/core/src/main/scala/Hash.scala
+++ b/core/src/main/scala/Hash.scala
@@ -28,11 +28,11 @@ object PositionHash:
 
 opaque type Hash = Int
 object Hash:
-  val size                      = 3
-  def apply(value: Int): Hash   = value >>> 8
-  def apply(board: Board): Hash = hashBoard(board) >>> 8
+  val size                         = 3
+  def apply(value: Int): Hash      = value >>> 8
+  def apply(board: Position): Hash = hashBoard(board) >>> 8
 
-  private def hashBoard(board: Board): Int =
+  private def hashBoard(board: Position): Int =
 
     val hPieces =
       var h = 0

--- a/core/src/main/scala/InsufficientMatingMaterial.scala
+++ b/core/src/main/scala/InsufficientMatingMaterial.scala
@@ -9,14 +9,14 @@ object InsufficientMatingMaterial:
 
   // verify if there are at least two bishops of opposite color
   // no matter which sides they are on
-  def bishopsOnOppositeColors(board: Board): Boolean =
+  def bishopsOnOppositeColors(board: Position): Boolean =
     board.bishops.map(_.isLight).distinct.size == 2
 
   /*
    * Returns true if a pawn cannot progress forward because it is blocked by a pawn
    * and it doesn't have any capture
    */
-  def pawnBlockedByPawn(pawn: Square, board: Board): Boolean =
+  def pawnBlockedByPawn(pawn: Square, board: Position): Boolean =
     board(pawn).exists(p =>
       p.is(Pawn) &&
         board.withColor(p.color).generateMovesAt(pawn).isEmpty && {
@@ -29,7 +29,7 @@ object InsufficientMatingMaterial:
    * Determines whether a board position is an automatic draw due to neither player
    * being able to mate the other as informed by the traditional chess rules.
    */
-  def apply(board: Board): Boolean =
+  def apply(board: Position): Boolean =
     board.kingsAndMinorsOnly &&
       (board.nbPieces <= 3 || (board.kingsAndBishopsOnly && !bishopsOnOppositeColors(board)))
 
@@ -40,7 +40,7 @@ object InsufficientMatingMaterial:
    * King + bishop mates against king + any(bishop, knight, pawn)
    * King + bishop(s) versus king + bishop(s) depends upon bishop square colors
    */
-  def apply(board: Board, color: Color): Boolean =
+  def apply(board: Position, color: Color): Boolean =
     if board.kingsOnlyOf(color) then true
     else if board.kingsAndKnightsOnlyOf(color) then
       board.nonKingsOf(color).count == 1 &&

--- a/core/src/main/scala/MoveOrDrop.scala
+++ b/core/src/main/scala/MoveOrDrop.scala
@@ -134,9 +134,9 @@ case class Move(
   def withPromotion(p: PromotableRole): Option[Move] =
     if after.count(color.queen) > boardBefore.count(color.queen) then
       for
-        b2 <- after.take(dest)
-        b3 <- b2.place(color - p, dest)
-      yield copy(after = b3, promotion = Option(p))
+        b2 <- after.board.take(dest)
+        b3 <- b2.put(color - p, dest)
+      yield copy(after = after.withBoard(b3), promotion = Option(p))
     else this.some
 
   inline def withAfter(newBoard: Position): Move = copy(after = newBoard)

--- a/core/src/main/scala/Piece.scala
+++ b/core/src/main/scala/Piece.scala
@@ -3,8 +3,6 @@ package chess
 import cats.Eq
 import cats.derived.*
 
-import Bitboard.*
-
 case class Piece(color: Color, role: Role) derives Eq:
 
   def is(c: Color)   = c == color

--- a/core/src/main/scala/Piece.scala
+++ b/core/src/main/scala/Piece.scala
@@ -3,8 +3,7 @@ package chess
 import cats.Eq
 import cats.derived.*
 
-import bitboard.Bitboard
-import bitboard.Bitboard.*
+import Bitboard.*
 
 case class Piece(color: Color, role: Role) derives Eq:
 

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -4,7 +4,6 @@ import cats.syntax.all.*
 import chess.format.Uci
 
 import variant.*
-import Bitboard.*
 
 case class Position(board: Board, history: History, variant: Variant, color: Color):
 
@@ -244,7 +243,7 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
   def genKnight(knights: Bitboard, mask: Bitboard): List[Move] =
     for
       from <- knights
-      to   <- Bitboard.knightAttacks(from) & mask
+      to   <- from.knightAttacks & mask
       move <- normalMove(from, to, Knight, isOccupied(to))
     yield move
 

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -4,7 +4,7 @@ import cats.syntax.all.*
 import chess.format.Uci
 
 import variant.*
-import bitboard.{ Bitboard, Board }
+import bitboard.Bitboard
 import bitboard.Bitboard.*
 
 case class Position(board: Board, history: History, variant: Variant, color: Color):

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -4,8 +4,7 @@ import cats.syntax.all.*
 import chess.format.Uci
 
 import variant.*
-import bitboard.Bitboard
-import bitboard.Bitboard.*
+import Bitboard.*
 
 case class Position(board: Board, history: History, variant: Variant, color: Color):
 

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -4,11 +4,10 @@ import cats.syntax.all.*
 import chess.format.Uci
 
 import variant.*
-import bitboard.Board as BBoard
-import bitboard.Bitboard
+import bitboard.{ Bitboard, Board }
 import bitboard.Bitboard.*
 
-case class Position(board: BBoard, history: History, variant: Variant, color: Color):
+case class Position(board: Board, history: History, variant: Variant, color: Color):
 
   export history.{ castles, unmovedRooks, crazyData }
   // format: off
@@ -45,7 +44,7 @@ case class Position(board: BBoard, history: History, variant: Variant, color: Co
 
   def unary_! : Position = withColor(color = !color)
 
-  def withPieces(newPieces: PieceMap) = copy(board = BBoard.fromMap(newPieces))
+  def withPieces(newPieces: PieceMap) = copy(board = Board.fromMap(newPieces))
 
   def withVariant(v: Variant): Position =
     if v == Crazyhouse then copy(variant = v).ensureCrazyData
@@ -60,7 +59,7 @@ case class Position(board: BBoard, history: History, variant: Variant, color: Co
 
   inline def updateHistory(inline f: History => History): Position = copy(history = f(history))
 
-  def withBoard(b: BBoard): Position = copy(board = b)
+  def withBoard(b: Board): Position = copy(board = b)
 
   def withColor(color: Color): Position = copy(color = color)
 
@@ -427,9 +426,9 @@ object Position:
       crazyData: Option[Crazyhouse.Data],
       color: Option[Color]
   ) =
-    new Position(BBoard.fromMap(pieces), history.copy(crazyData = crazyData), variant, color.getOrElse(White))
+    new Position(Board.fromMap(pieces), history.copy(crazyData = crazyData), variant, color.getOrElse(White))
 
-  def apply(board: BBoard, variant: Variant, color: Option[Color]): Position =
+  def apply(board: Board, variant: Variant, color: Option[Color]): Position =
     val unmovedRooks = if variant.allowsCastling then UnmovedRooks(board.rooks) else UnmovedRooks.none
     Position(
       board,
@@ -451,7 +450,7 @@ object Position:
       variant: Variant,
       color: Option[Color]
   ): Position =
-    val board        = BBoard.fromMap(pieces.toMap)
+    val board        = Board.fromMap(pieces.toMap)
     val unmovedRooks = if variant.allowsCastling then UnmovedRooks(board.rooks) else UnmovedRooks.none
     Position(
       board,
@@ -466,4 +465,4 @@ object Position:
 
   def apply(variant: chess.variant.Variant): Position = Position.init(variant, White)
   def init(variant: Variant, color: Color): Position =
-    Position(BBoard.fromMap(variant.pieces), variant, color.some)
+    Position(Board.fromMap(variant.pieces), variant, color.some)

--- a/core/src/main/scala/Rank.scala
+++ b/core/src/main/scala/Rank.scala
@@ -1,7 +1,5 @@
 package chess
 
-import chess.bitboard.Bitboard
-
 opaque type Rank = Int
 object Rank:
   extension (a: Rank)

--- a/core/src/main/scala/Role.scala
+++ b/core/src/main/scala/Role.scala
@@ -125,7 +125,7 @@ case class ByRole[A](pawn: A, knight: A, bishop: A, rook: A, queen: A, king: A):
 
 object ByRole:
 
-  def apply[A](a: A): ByRole[A] = ByRole(a, a, a, a, a, a)
+  def fill[A](a: A): ByRole[A] = ByRole(a, a, a, a, a, a)
 
   given Functor[ByRole] with
     def map[A, B](byRole: ByRole[A])(f: A => B): ByRole[B] =

--- a/core/src/main/scala/Role.scala
+++ b/core/src/main/scala/Role.scala
@@ -2,7 +2,6 @@ package chess
 
 import cats.Functor
 import cats.syntax.all.*
-import chess.bitboard.Bitboard
 
 sealed trait Role:
   val forsyth: Char

--- a/core/src/main/scala/Square.scala
+++ b/core/src/main/scala/Square.scala
@@ -1,7 +1,5 @@
 package chess
 
-import chess.bitboard.Bitboard
-
 import java.lang.Math.abs
 import scala.annotation.targetName
 

--- a/core/src/main/scala/Square.scala
+++ b/core/src/main/scala/Square.scala
@@ -3,6 +3,9 @@ package chess
 import java.lang.Math.abs
 import scala.annotation.targetName
 
+import bitboard.Attacks.*
+import bitboard.Magic
+
 opaque type Square = Int
 object Square:
   extension (s: Square)
@@ -59,6 +62,22 @@ object Square:
 
     inline def bb: Bitboard = Bitboard(1L << s.value)
     inline def bl: Long     = 1L << s.value
+
+    def bishopAttacks(occupied: Bitboard): Bitboard =
+      Bitboard(ATTACKS(Magic.BISHOP(s.value).bishopIndex(occupied.value)))
+
+    def rookAttacks(occupied: Bitboard): Bitboard =
+      Bitboard(ATTACKS(Magic.ROOK(s.value).rookIndex(occupied.value)))
+
+    def queenAttacks(occupied: Bitboard): Bitboard =
+      bishopAttacks(occupied) ^ rookAttacks(occupied)
+
+    def pawnAttacks(color: Color): Bitboard =
+      Bitboard(color.fold(WHITE_PAWN_ATTACKS(s), BLACK_PAWN_ATTACKS(s)))
+
+    def kingAttacks: Bitboard = Bitboard(KING_ATTACKS(s))
+
+    def knightAttacks: Bitboard = Bitboard(KNIGHT_ATTACKS(s))
 
   end extension
 

--- a/core/src/main/scala/UnmovedRooks.scala
+++ b/core/src/main/scala/UnmovedRooks.scala
@@ -2,8 +2,6 @@ package chess
 
 import scala.annotation.targetName
 
-import bitboard.Bitboard
-
 opaque type UnmovedRooks = Long
 object UnmovedRooks:
   // for lila testing only

--- a/core/src/main/scala/UnmovedRooks.scala
+++ b/core/src/main/scala/UnmovedRooks.scala
@@ -16,7 +16,7 @@ object UnmovedRooks:
 
   // guess unmovedRooks from board
   // we assume rooks are on their initial position
-  def from(board: Position): UnmovedRooks =
+  def from(board: Board): UnmovedRooks =
     val wr = board.rooks & board.white & Bitboard.rank(White.backRank)
     val br = board.rooks & board.black & Bitboard.rank(Black.backRank)
     UnmovedRooks(wr | br)

--- a/core/src/main/scala/UnmovedRooks.scala
+++ b/core/src/main/scala/UnmovedRooks.scala
@@ -18,7 +18,7 @@ object UnmovedRooks:
 
   // guess unmovedRooks from board
   // we assume rooks are on their initial position
-  def from(board: Board): UnmovedRooks =
+  def from(board: Position): UnmovedRooks =
     val wr = board.rooks & board.white & Bitboard.rank(White.backRank)
     val br = board.rooks & board.black & Bitboard.rank(Black.backRank)
     UnmovedRooks(wr | br)

--- a/core/src/main/scala/bitboard/Attacks.scala
+++ b/core/src/main/scala/bitboard/Attacks.scala
@@ -9,25 +9,25 @@ object Attacks:
   private val all = -1L
 
   @static
-  private[bitboard] val RANKS = Array.fill(8)(0L)
+  private[chess] val RANKS = Array.fill(8)(0L)
   @static
-  private[bitboard] val FILES = Array.fill(8)(0L)
+  private[chess] val FILES = Array.fill(8)(0L)
   @static
-  private[bitboard] val BETWEEN = Array.ofDim[Long](64, 64)
+  private[chess] val BETWEEN = Array.ofDim[Long](64, 64)
   @static
-  private[bitboard] val RAYS = Array.ofDim[Long](64, 64)
+  private[chess] val RAYS = Array.ofDim[Long](64, 64)
 
   // Large overlapping attack table indexed using magic multiplication.
   @static
-  private[bitboard] val ATTACKS = Array.fill(88772)(0L)
+  private[chess] val ATTACKS = Array.fill(88772)(0L)
   @static
-  private[bitboard] val KNIGHT_ATTACKS = Array.fill(64)(0L)
+  private[chess] val KNIGHT_ATTACKS = Array.fill(64)(0L)
   @static
-  private[bitboard] val KING_ATTACKS = Array.fill(64)(0L)
+  private[chess] val KING_ATTACKS = Array.fill(64)(0L)
   @static
-  private[bitboard] val WHITE_PAWN_ATTACKS = Array.fill(64)(0L)
+  private[chess] val WHITE_PAWN_ATTACKS = Array.fill(64)(0L)
   @static
-  private[bitboard] val BLACK_PAWN_ATTACKS = Array.fill(64)(0L)
+  private[chess] val BLACK_PAWN_ATTACKS = Array.fill(64)(0L)
 
   @static
   private val KNIGHT_DELTAS = Array[Int](17, 15, 10, 6, -17, -15, -10, -6)

--- a/core/src/main/scala/bitboard/Magic.scala
+++ b/core/src/main/scala/bitboard/Magic.scala
@@ -9,7 +9,7 @@ class Magic(val mask: Long, val factor: Long, val offset: Int):
 
 object Magic:
   @static
-  private[bitboard] val ROOK = Array[Magic](
+  private[chess] val ROOK = Array[Magic](
     Magic(0x000101010101017eL, 0x00280077ffebfffeL, 26304),
     Magic(0x000202020202027cL, 0x2004010201097fffL, 35520),
     Magic(0x000404040404047aL, 0x0010020010053fffL, 38592),
@@ -77,7 +77,7 @@ object Magic:
   )
 
   @static
-  private[bitboard] val BISHOP = Array[Magic](
+  private[chess] val BISHOP = Array[Magic](
     Magic(0x0040201008040200L, 0x007fbfbfbfbfbfffL, 5378),
     Magic(0x0000402010080400L, 0x0000a060401007fcL, 4093),
     Magic(0x0000004020100a00L, 0x0001004008020000L, 4314),

--- a/core/src/main/scala/format/BinaryFen.scala
+++ b/core/src/main/scala/format/BinaryFen.scala
@@ -10,7 +10,7 @@ case class BinaryFen(value: Array[Byte]) extends AnyVal:
 
   import BinaryFen.implementation.*
 
-  def read: Board.AndFullMoveNumber =
+  def read: Position.AndFullMoveNumber =
     val reader = new Iterator[Byte]:
       val inner                            = value.iterator
       override inline def hasNext: Boolean = inner.hasNext
@@ -135,8 +135,8 @@ case class BinaryFen(value: Array[Byte]) extends AnyVal:
       )
     else None
 
-    Board.AndFullMoveNumber(
-      Board(
+    Position.AndFullMoveNumber(
+      Position(
         BBoard(
           occupied = occupied,
           white = white,
@@ -171,9 +171,9 @@ object BinaryFen:
 
   import BinaryFen.implementation.*
 
-  def writeNormalized(board: Board): BinaryFen =
+  def writeNormalized(board: Position): BinaryFen =
     write(
-      Board.AndFullMoveNumber(
+      Position.AndFullMoveNumber(
         board
           .updateHistory(_.setHalfMoveClock(HalfMoveClock.initial))
           .withVariant(board.variant match
@@ -183,7 +183,7 @@ object BinaryFen:
       )
     )
 
-  def write(input: Board.AndFullMoveNumber) = BinaryFen:
+  def write(input: Position.AndFullMoveNumber) = BinaryFen:
     val builder = ArrayBuilder.ofByte()
     builder.sizeHint(8 + 32)
 
@@ -303,7 +303,7 @@ object BinaryFen:
       val b = reader.next
       ((b & 0xf), (b >>> 4) & 0xf)
 
-    def minimumUnmovedRooks(board: Board): UnmovedRooks =
+    def minimumUnmovedRooks(board: Position): UnmovedRooks =
       val white   = board.history.unmovedRooks.bb & board.white & Bitboard.firstRank
       val black   = board.history.unmovedRooks.bb & board.black & Bitboard.lastRank
       val castles = board.history.castles

--- a/core/src/main/scala/format/BinaryFen.scala
+++ b/core/src/main/scala/format/BinaryFen.scala
@@ -1,7 +1,7 @@
 package chess
 package format
 
-import chess.bitboard.{ Bitboard, Board as BBoard }
+import chess.bitboard.{ Bitboard, Board }
 import chess.variant.*
 
 import scala.collection.mutable.ArrayBuilder
@@ -137,7 +137,7 @@ case class BinaryFen(value: Array[Byte]) extends AnyVal:
 
     Position.AndFullMoveNumber(
       Position(
-        BBoard(
+        Board(
           occupied = occupied,
           white = white,
           black = black,

--- a/core/src/main/scala/format/BinaryFen.scala
+++ b/core/src/main/scala/format/BinaryFen.scala
@@ -1,7 +1,7 @@
 package chess
 package format
 
-import chess.bitboard.{ Bitboard, Board }
+import chess.bitboard.Bitboard
 import chess.variant.*
 
 import scala.collection.mutable.ArrayBuilder

--- a/core/src/main/scala/format/BinaryFen.scala
+++ b/core/src/main/scala/format/BinaryFen.scala
@@ -1,7 +1,6 @@
 package chess
 package format
 
-import chess.bitboard.Bitboard
 import chess.variant.*
 
 import scala.collection.mutable.ArrayBuilder

--- a/core/src/main/scala/format/FenReader.scala
+++ b/core/src/main/scala/format/FenReader.scala
@@ -7,7 +7,6 @@ import scalalib.zeros.given
 
 import variant.{ Standard, Variant }
 import variant.Crazyhouse.Pockets
-import bitboard.Bitboard
 
 /** https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
   *

--- a/core/src/main/scala/format/FenReader.scala
+++ b/core/src/main/scala/format/FenReader.scala
@@ -17,13 +17,13 @@ import bitboard.Board as BBoard
   * http://scidb.sourceforge.net/help/en/FEN.html#ThreeCheck
   */
 trait FenReader:
-  def read(variant: Variant, fen: FullFen): Option[Board] =
+  def read(variant: Variant, fen: FullFen): Option[Position] =
     val (fBoard, fColor, fCastling, fEnpassant) = fen.parts
     makeBoard(variant, fBoard).map { (bboard, crazyData) =>
       // We trust Fen's color to be correct, if there is no color we use the color of the king in check
       // If there is no king in check we use white
       val color = fColor.orElse(variant.checkColor(bboard)) | Color.White
-      val board: Board = new Board(
+      val board: Position = new Position(
         bboard,
         History(
           unmovedRooks = variant.makeUnmovedRooks(bboard.rooks),
@@ -82,18 +82,18 @@ trait FenReader:
           checkCount.foldLeft(history)(_.withCheckCount(_))
     }
 
-  def read(fen: FullFen): Option[Board] = read(Standard, fen)
+  def read(fen: FullFen): Option[Position] = read(Standard, fen)
 
-  def readWithMoveNumber(variant: Variant, fen: FullFen): Option[Board.AndFullMoveNumber] =
+  def readWithMoveNumber(variant: Variant, fen: FullFen): Option[Position.AndFullMoveNumber] =
     read(variant, fen).map { sit =>
       val (halfMoveClock, fullMoveNumber) = readHalfMoveClockAndFullMoveNumber(fen)
-      Board.AndFullMoveNumber(
+      Position.AndFullMoveNumber(
         halfMoveClock.map(sit.history.setHalfMoveClock).fold(sit)(x => sit.updateHistory(_ => x)),
         fullMoveNumber | FullMoveNumber(1)
       )
     }
 
-  def readWithMoveNumber(fen: FullFen): Option[Board.AndFullMoveNumber] =
+  def readWithMoveNumber(fen: FullFen): Option[Position.AndFullMoveNumber] =
     readWithMoveNumber(Standard, fen)
 
   def readHalfMoveClockAndFullMoveNumber(fen: FullFen): (Option[HalfMoveClock], Option[FullMoveNumber]) =

--- a/core/src/main/scala/format/FenReader.scala
+++ b/core/src/main/scala/format/FenReader.scala
@@ -7,7 +7,7 @@ import scalalib.zeros.given
 
 import variant.{ Standard, Variant }
 import variant.Crazyhouse.Pockets
-import bitboard.{ Bitboard, Board }
+import bitboard.Bitboard
 
 /** https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
   *

--- a/core/src/main/scala/format/FenReader.scala
+++ b/core/src/main/scala/format/FenReader.scala
@@ -7,8 +7,7 @@ import scalalib.zeros.given
 
 import variant.{ Standard, Variant }
 import variant.Crazyhouse.Pockets
-import bitboard.Bitboard
-import bitboard.Board as BBoard
+import bitboard.{ Bitboard, Board }
 
 /** https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
   *
@@ -126,7 +125,7 @@ trait FenReader:
       case _ => None
 
   // only cares about pieces positions on the board (first part of FEN string)
-  def makeBoard(variant: Variant, fen: String): Option[(BBoard, Option[Crazyhouse.Data])] =
+  def makeBoard(variant: Variant, fen: String): Option[(Board, Option[Crazyhouse.Data])] =
     val (position, pocketsStr) = fen.takeWhile(' ' !=) match
       case word if word.count('/' ==) == 8 =>
         val splitted = word.split('/')
@@ -143,7 +142,7 @@ trait FenReader:
 
   private val numberSet = Set.from('1' to '8')
 
-  type BoardWithCrazyPromoted = (BBoard, Bitboard)
+  type BoardWithCrazyPromoted = (Board, Bitboard)
 
   def makeBoardOptionWithCrazyPromoted(boardFen: String, variant: Variant): Option[BoardWithCrazyPromoted] =
     val (board, error) = makeBoardWithCrazyPromoted(boardFen, variant)
@@ -206,7 +205,7 @@ trait FenReader:
                     iter.next
                 case None => error = Some(s"invalid piece $ch")
             file += 1
-    val bboard = BBoard(
+    val bboard = Board(
       occupied = occupied,
       white = white,
       black = black,

--- a/core/src/main/scala/format/FenWriter.scala
+++ b/core/src/main/scala/format/FenWriter.scala
@@ -15,16 +15,16 @@ trait FenWriter:
   private given Ordering[File] = Ordering.by[File, Int](_.value)
   given Ordering[Square]       = Ordering.by[Square, File](_.file)
 
-  def write(board: Board): FullFen =
+  def write(board: Position): FullFen =
     write(board, FullMoveNumber(1))
 
-  def write(parsed: Board.AndFullMoveNumber): FullFen =
+  def write(parsed: Position.AndFullMoveNumber): FullFen =
     write(parsed.board, parsed.fullMoveNumber)
 
   def write(game: Game): FullFen =
     write(game.board, game.ply.fullMoveNumber)
 
-  def write(board: Board, fullMoveNumber: FullMoveNumber): FullFen = FullFen:
+  def write(board: Position, fullMoveNumber: FullMoveNumber): FullFen = FullFen:
     val builder = scala.collection.mutable.StringBuilder(80)
     builder.append(writeBoard(board))
     builder.append(writeCrazyPocket(board))
@@ -43,11 +43,11 @@ trait FenWriter:
       builder.append(writeCheckCount(board))
     builder.toString
 
-  def writeOpening(board: Board): StandardFen = StandardFen:
+  def writeOpening(board: Position): StandardFen = StandardFen:
     s"${writeBoard(board)} ${board.color.letter} ${writeCastles(board)} ${board.enPassantSquare
         .fold("-")(_.key)}"
 
-  def writeBoard(board: Board): BoardFen =
+  def writeBoard(board: Position): BoardFen =
     val fen   = scala.collection.mutable.StringBuilder(70)
     var empty = 0
     for y <- Rank.allReversed do
@@ -66,23 +66,23 @@ trait FenWriter:
       if y > Rank.First then fen.append('/')
     BoardFen(fen.toString)
 
-  def writeBoardAndColor(board: Board): BoardAndColorFen =
+  def writeBoardAndColor(board: Position): BoardAndColorFen =
     writeBoardAndColor(board, board.color)
 
-  def writeBoardAndColor(board: Board, turnColor: Color): BoardAndColorFen =
+  def writeBoardAndColor(board: Position, turnColor: Color): BoardAndColorFen =
     writeBoard(board).andColor(turnColor)
 
-  private def writeCheckCount(board: Board) =
+  private def writeCheckCount(board: Position) =
     board.history.checkCount match
       case CheckCount(white, black) => s"+$black+$white"
 
-  private def writeCrazyPocket(board: Board) =
+  private def writeCrazyPocket(board: Position) =
     board.crazyData match
       case Some(variant.Crazyhouse.Data(pockets, _)) =>
         "/" + pockets.forsyth
       case _ => ""
 
-  private[chess] def writeCastles(board: Board): String =
+  private[chess] def writeCastles(board: Position): String =
     val wr  = board.rooks & board.white & Bitboard.rank(White.backRank)
     val br  = board.rooks & board.black & Bitboard.rank(Black.backRank)
     val wur = board.unmovedRooks.without(Black).bb

--- a/core/src/main/scala/format/FenWriter.scala
+++ b/core/src/main/scala/format/FenWriter.scala
@@ -2,7 +2,6 @@ package chess
 package format
 
 import cats.syntax.all.*
-import chess.bitboard.Bitboard
 
 /** https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation
   *

--- a/core/src/main/scala/format/Uci.scala
+++ b/core/src/main/scala/format/Uci.scala
@@ -10,7 +10,7 @@ sealed trait Uci:
 
   def origDest: (Square, Square)
 
-  def apply(board: Board): Either[ErrorStr, MoveOrDrop]
+  def apply(board: Position): Either[ErrorStr, MoveOrDrop]
 
 object Uci:
 
@@ -30,7 +30,7 @@ object Uci:
 
     def origDest: (Square, Square) = orig -> dest
 
-    def apply(board: Board): Either[ErrorStr, MoveOrDrop] = board.move(orig, dest, promotion)
+    def apply(board: Position): Either[ErrorStr, MoveOrDrop] = board.move(orig, dest, promotion)
 
     override def toString = s"Move(${orig.key}${dest.key}${promotion.fold("")(_.forsyth)})"
 
@@ -62,7 +62,7 @@ object Uci:
 
     def origDest: (Square, Square) = square -> square
 
-    def apply(board: Board): Either[ErrorStr, MoveOrDrop] = board.drop(role, square)
+    def apply(board: Position): Either[ErrorStr, MoveOrDrop] = board.drop(role, square)
 
   object Drop:
 

--- a/core/src/main/scala/format/pgn/Dumper.scala
+++ b/core/src/main/scala/format/pgn/Dumper.scala
@@ -5,7 +5,7 @@ object Dumper:
 
   def apply(board: Position, data: chess.Move, next: Position): SanStr =
     import data.*
-    import bitboard.Bitboard.*
+    import Bitboard.*
 
     val base = (promotion, piece.role) match
       case _ if castles =>

--- a/core/src/main/scala/format/pgn/Dumper.scala
+++ b/core/src/main/scala/format/pgn/Dumper.scala
@@ -3,7 +3,7 @@ package format.pgn
 
 object Dumper:
 
-  def apply(board: Board, data: chess.Move, next: Board): SanStr =
+  def apply(board: Position, data: chess.Move, next: Position): SanStr =
     import data.*
     import bitboard.Bitboard.*
 
@@ -43,7 +43,7 @@ object Dumper:
 
     SanStr(s"$base${checkOrWinnerSymbol(next)}")
 
-  def apply(data: chess.Drop, next: Board): SanStr =
+  def apply(data: chess.Drop, next: Position): SanStr =
     SanStr(s"${data.toUci.uci}${checkOrWinnerSymbol(next)}")
 
   def apply(data: chess.Move): SanStr =
@@ -52,7 +52,7 @@ object Dumper:
   def apply(data: chess.Drop): SanStr =
     apply(data, data.boardAfter)
 
-  private def checkOrWinnerSymbol(next: Board): String =
+  private def checkOrWinnerSymbol(next: Position): String =
     if next.winner.isDefined then "#"
     else if next.check.yes then "+"
     else ""

--- a/core/src/main/scala/format/pgn/Dumper.scala
+++ b/core/src/main/scala/format/pgn/Dumper.scala
@@ -5,7 +5,6 @@ object Dumper:
 
   def apply(board: Position, data: chess.Move, next: Position): SanStr =
     import data.*
-    import Bitboard.*
 
     val base = (promotion, piece.role) match
       case _ if castles =>

--- a/core/src/main/scala/format/pgn/parsingModel.scala
+++ b/core/src/main/scala/format/pgn/parsingModel.scala
@@ -45,7 +45,7 @@ case class ParsedPgn(initialPosition: InitialComments, tags: Tags, tree: Option[
 
   private def initContext(tags: Tags): AndFullMoveNumber =
     val variant = tags.variant | chess.variant.Standard
-    def default = Position.AndFullMoveNumber(Position.init(variant, White), FullMoveNumber.initial)
+    def default = AndFullMoveNumber(Position.init(variant, White), FullMoveNumber.initial)
 
     tags.fen
       .flatMap(Fen.readWithMoveNumber(variant, _))
@@ -61,7 +61,7 @@ case class ParsedMainline[A](initialPosition: InitialComments, tags: Tags, sans:
 
 // Standard Algebraic Notation
 sealed trait San:
-  def apply(board: Position): Either[ErrorStr, MoveOrDrop]
+  def apply(position: Position): Either[ErrorStr, MoveOrDrop]
   def rawString: Option[String] = None
 
 case class Std(

--- a/core/src/main/scala/opening/OpeningDb.scala
+++ b/core/src/main/scala/opening/OpeningDb.scala
@@ -54,7 +54,7 @@ object OpeningDb:
       moves.map(_.boardBefore) ++ moves.lastOption.map(_.boardAfter).toVector
 
   // first board is initial position
-  def searchInBoards(boards: Iterable[Board]): Option[Opening.AtPly] =
+  def searchInBoards(boards: Iterable[Position]): Option[Opening.AtPly] =
     boards
       .takeWhile(_.board.nbPieces >= SEARCH_MIN_PIECES)
       .zipWithIndex

--- a/core/src/main/scala/variant/Antichess.scala
+++ b/core/src/main/scala/variant/Antichess.scala
@@ -1,7 +1,7 @@
 package chess
 package variant
 
-import chess.bitboard.Board as BBoard
+import chess.bitboard.Board
 import chess.format.FullFen
 
 case object Antichess
@@ -24,7 +24,7 @@ case object Antichess
   // In antichess, the king can't be put into check so we always return false
   override def kingSafety(m: Move): Boolean = true
 
-  override def kingThreatened(board: BBoard, color: Color): Check = Check.No
+  override def kingThreatened(board: Board, color: Color): Check = Check.No
 
   override def validMoves(board: Position): List[Move] =
     import board.{ genNonKing, genUnsafeKing, ourKings }

--- a/core/src/main/scala/variant/Antichess.scala
+++ b/core/src/main/scala/variant/Antichess.scala
@@ -26,35 +26,35 @@ case object Antichess
 
   override def kingThreatened(board: BBoard, color: Color): Check = Check.No
 
-  override def validMoves(board: Board): List[Move] =
+  override def validMoves(board: Position): List[Move] =
     import board.{ genNonKing, genUnsafeKing, ourKings }
     val capturingMoves = captureMoves(board)
     if capturingMoves.nonEmpty then capturingMoves
     else genNonKing(~board.occupied) ++ ourKings.flatMap(genUnsafeKing(_, ~board.occupied))
 
-  def captureMoves(board: Board): List[Move] =
+  def captureMoves(board: Position): List[Move] =
     import board.{ them, us, genNonKing, genEnPassant, genUnsafeKing, ourKings }
     ourKings.flatMap(genUnsafeKing(_, them)) ++ genEnPassant(us & board.pawns) ++ genNonKing(them)
 
-  override def valid(board: Board, strict: Boolean): Boolean =
+  override def valid(board: Position, strict: Boolean): Boolean =
     board.nbPieces >= 2 && board.nbPieces <= 32
 
   // In antichess, there is no checkmate condition, and the winner is the current player if they have no legal moves
-  override def winner(board: Board): Option[Color] =
+  override def winner(board: Position): Option[Color] =
     specialEnd(board).option(board.color)
 
-  override def specialEnd(board: Board): Boolean =
+  override def specialEnd(board: Position): Boolean =
     // The game ends with a win when one player manages to lose all their pieces or is in stalemate
     board(board.color).isEmpty || board.legalMoves.isEmpty
 
   // In antichess, it is valuable for your opponent to have pieces.
-  override def materialImbalance(board: Board): Int =
+  override def materialImbalance(board: Position): Int =
     board.fold(0): (acc, color, _) =>
       acc + color.fold(-2, 2)
 
   // In antichess, there is no checkmate condition therefore a player may only draw either by agreement,
   // blockade or stalemate. Only one player can win if the only remaining pieces are two knights
-  override def opponentHasInsufficientMaterial(board: Board) =
+  override def opponentHasInsufficientMaterial(board: Position) =
     // Exit early if we are not in a board with only knights
     board.onlyKnights && {
 
@@ -69,7 +69,7 @@ case object Antichess
   // No player can win if the only remaining pieces are opposing bishops on different coloured
   // diagonals. There may be pawns that are incapable of moving and do not attack the right color
   // of square to allow the player to force their opponent to capture their bishop, also resulting in a draw
-  override def isInsufficientMaterial(board: Board): Boolean =
+  override def isInsufficientMaterial(board: Position): Boolean =
     // Exit early if we are not in a board with only bishops and pawns
     if (board.bishops | board.pawns) != board.occupied then false
     else
@@ -89,7 +89,7 @@ case object Antichess
         ) && blackPawns.forall(pawnNotAttackable(_, whiteBishopLight, board)))
           .getOrElse(false)
 
-  private def pawnNotAttackable(pawn: Square, oppositeBishopLight: Boolean, board: Board): Boolean =
+  private def pawnNotAttackable(pawn: Square, oppositeBishopLight: Boolean, board: Position): Boolean =
     // The pawn cannot attack a bishop or be attacked by a bishop
     val cannotAttackBishop = pawn.isLight != oppositeBishopLight
     InsufficientMatingMaterial.pawnBlockedByPawn(pawn, board) && cannotAttackBishop

--- a/core/src/main/scala/variant/Antichess.scala
+++ b/core/src/main/scala/variant/Antichess.scala
@@ -1,7 +1,6 @@
 package chess
 package variant
 
-import chess.bitboard.Board
 import chess.format.FullFen
 
 case object Antichess

--- a/core/src/main/scala/variant/Atomic.scala
+++ b/core/src/main/scala/variant/Atomic.scala
@@ -1,7 +1,7 @@
 package chess
 package variant
 
-import bitboard.{ Bitboard, Board }
+import bitboard.Bitboard
 import bitboard.Bitboard.*
 
 case object Atomic

--- a/core/src/main/scala/variant/Atomic.scala
+++ b/core/src/main/scala/variant/Atomic.scala
@@ -1,8 +1,6 @@
 package chess
 package variant
 
-import Bitboard.*
-
 case object Atomic
     extends Variant(
       id = Variant.Id(7),

--- a/core/src/main/scala/variant/Atomic.scala
+++ b/core/src/main/scala/variant/Atomic.scala
@@ -18,23 +18,23 @@ case object Atomic
 
   def pieces = Standard.pieces
 
-  def validMoves(board: Board): List[Move] =
+  def validMoves(board: Position): List[Move] =
     import board.{ genNonKing, genEnPassant, us }
     val targets = ~us
     val moves   = genNonKing(targets) ++ genKing(board, targets) ++ genEnPassant(us & board.pawns)
     moves.map(explodeSurroundingPieces).filter(kingSafety)
 
-  private def genKing(board: Board, mask: Bitboard) =
+  private def genKing(board: Position, mask: Bitboard) =
     import board.{ genUnsafeKing, genCastling }
     board.ourKing.fold(Nil): king =>
       genCastling(king) ++ genUnsafeKing(king, mask)
 
   /** Move threatens to explode the opponent's king */
-  private def explodesOpponentKing(board: Board)(move: Move): Boolean =
+  private def explodesOpponentKing(board: Position)(move: Move): Boolean =
     move.captures && (board.them & board.kings).intersects(move.dest.kingAttacks)
 
   /** Move threatens to illegally explode our own king */
-  private def explodesOwnKing(board: Board)(move: Move): Boolean =
+  private def explodesOwnKing(board: Position)(move: Move): Boolean =
     move.captures && (board.us & board.kings).intersects(move.dest.kingAttacks)
 
   /** In atomic chess, a king cannot be threatened while it is in the perimeter of the other king as were the other player
@@ -62,7 +62,12 @@ case object Atomic
       explodesOpponentKing(m.boardBefore)(m))
       && !explodesOwnKing(m.boardBefore)(m)
 
-  override def castleCheckSafeSquare(board: Board, king: Square, color: Color, occupied: Bitboard): Boolean =
+  override def castleCheckSafeSquare(
+      board: Position,
+      king: Square,
+      color: Color,
+      occupied: Bitboard
+  ): Boolean =
     king.kingAttacks.intersects(board.kingOf(!color)) ||
       attackersWithoutKing(board.board, occupied, king, !color).isEmpty
 
@@ -86,7 +91,7 @@ case object Atomic
   /** Since kings cannot confine each other, if either player has only a king
     * then either a queen or multiple pieces are required for checkmate.
     */
-  private def insufficientAtomicWinningMaterial(board: Board) =
+  private def insufficientAtomicWinningMaterial(board: Position) =
     lazy val bishopsOnOppositeColors = InsufficientMatingMaterial.bishopsOnOppositeColors(board)
 
     // Bishops of opposite color (no other pieces) endgames are dead drawn
@@ -103,12 +108,12 @@ case object Atomic
    * mate would be not be very likely. Additionally, a player can only mate another player with sufficient material.
    * We also look out for closed positions (pawns that cannot move and kings which cannot capture them.)
    */
-  override def isInsufficientMaterial(board: Board) =
+  override def isInsufficientMaterial(board: Position) =
     insufficientAtomicWinningMaterial(board) || atomicClosedPosition(board)
 
   /** Since a king cannot capture, K + P vs K + P where none of the pawns can move is an automatic draw
     */
-  private def atomicClosedPosition(board: Board) =
+  private def atomicClosedPosition(board: Position) =
     val closedStructure = board.pieces.forall((square, piece) =>
       InsufficientMatingMaterial.pawnBlockedByPawn(square, board)
         || piece.is(King) || piece.is(Bishop)
@@ -119,7 +124,7 @@ case object Atomic
       case None                  => true
     closedStructure && bishopsAbsentOrPawnitized
 
-  private def bishopPawnitized(board: Board, sideWithBishop: Color, bishopLight: Boolean) =
+  private def bishopPawnitized(board: Position, sideWithBishop: Color, bishopLight: Boolean) =
     board.pieces.forall((square, piece) =>
       (piece.is(Pawn) && piece.is(sideWithBishop)) ||
         (piece.is(Pawn) && piece.is(!sideWithBishop) && square.isLight == !bishopLight) ||
@@ -131,8 +136,8 @@ case object Atomic
     * a piece in the opponent's king's proximity. On the other hand, a king alone or a king with
     * immobile pawns is not sufficient material to win with.
     */
-  override def opponentHasInsufficientMaterial(board: Board) =
+  override def opponentHasInsufficientMaterial(board: Position) =
     board.kingsOnlyOf(!board.color)
 
   /** Atomic chess has a special end where a king has been killed by exploding with an adjacent captured piece */
-  override def specialEnd(board: Board) = board.kings.count < 2
+  override def specialEnd(board: Position) = board.kings.count < 2

--- a/core/src/main/scala/variant/Atomic.scala
+++ b/core/src/main/scala/variant/Atomic.scala
@@ -1,8 +1,7 @@
 package chess
 package variant
 
-import bitboard.Bitboard
-import bitboard.Bitboard.*
+import Bitboard.*
 
 case object Atomic
     extends Variant(

--- a/core/src/main/scala/variant/Atomic.scala
+++ b/core/src/main/scala/variant/Atomic.scala
@@ -1,8 +1,7 @@
 package chess
 package variant
 
-import bitboard.Bitboard
-import bitboard.Board as BBoard
+import bitboard.{ Bitboard, Board }
 import bitboard.Bitboard.*
 
 case object Atomic
@@ -41,13 +40,13 @@ case object Atomic
     * to capture it, their own king would explode. This effectively makes a king invincible while connected with another
     * king.
     */
-  override def kingThreatened(board: BBoard, color: Color): Check = Check:
+  override def kingThreatened(board: Board, color: Color): Check = Check:
     import board.{ kingPosOf, kingOf, occupied }
     kingPosOf(color).exists: k =>
       k.kingAttacks.isDisjoint(kingOf(!color)) &&
         attackersWithoutKing(board, occupied, k, !color).nonEmpty
 
-  private def attackersWithoutKing(board: BBoard, occupied: Bitboard, s: Square, attacker: Color) =
+  private def attackersWithoutKing(board: Board, occupied: Bitboard, s: Square, attacker: Color) =
     import board.{ byColor, rooks, queens, bishops, knights, pawns }
     byColor(attacker) & (
       s.rookAttacks(occupied) & (rooks ^ queens) |

--- a/core/src/main/scala/variant/Chess960.scala
+++ b/core/src/main/scala/variant/Chess960.scala
@@ -14,10 +14,10 @@ case object Chess960
       standardInitialPosition = false
     ):
 
-  def validMoves(board: Board): List[Move] =
+  def validMoves(board: Position): List[Move] =
     Standard.validMoves(board)
 
-  override def valid(board: Board, strict: Boolean): Boolean = Standard.valid(board, strict)
+  override def valid(board: Position, strict: Boolean): Boolean = Standard.valid(board, strict)
 
   def pieces = pieces(scala.util.Random.nextInt(960))
 

--- a/core/src/main/scala/variant/Crazyhouse.scala
+++ b/core/src/main/scala/variant/Crazyhouse.scala
@@ -4,8 +4,6 @@ package variant
 import chess.format.{ FullFen, Uci }
 import monocle.syntax.all.*
 
-import bitboard.Bitboard
-
 case object Crazyhouse
     extends Variant(
       id = Variant.Id(10),

--- a/core/src/main/scala/variant/FromPosition.scala
+++ b/core/src/main/scala/variant/FromPosition.scala
@@ -14,5 +14,5 @@ case object FromPosition
 
   def pieces = Standard.pieces
 
-  def validMoves(board: Board): List[Move] =
+  def validMoves(board: Position): List[Move] =
     Standard.validMoves(board)

--- a/core/src/main/scala/variant/Horde.scala
+++ b/core/src/main/scala/variant/Horde.scala
@@ -77,14 +77,14 @@ case object Horde
     * this method does not detect; however, such are trivial to premove.
     */
   override def opponentHasInsufficientMaterial(board: Position): Boolean =
-    hasInsufficientMaterial(board, !board.color) || hordeClosedPosition(board)
+    hasInsufficientMaterial(board.board, !board.color) || hordeClosedPosition(board)
 
-  extension (board: Position)
+  extension (board: Board)
     def hasBishopPair: Color => Boolean = side =>
       val bishops = board.bishops & board.byColor(side)
       bishops.intersects(Bitboard.lightSquares) && bishops.intersects(Bitboard.darkSquares)
 
-  def hasInsufficientMaterial(board: Position, color: Color): Boolean =
+  def hasInsufficientMaterial(board: Board, color: Color): Boolean =
     import SquareColor.*
     // Black can always win by capturing the horde
     if color.black then false

--- a/core/src/main/scala/variant/Horde.scala
+++ b/core/src/main/scala/variant/Horde.scala
@@ -35,26 +35,26 @@ case object Horde
     "rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1"
   )
 
-  def validMoves(board: Board): List[Move] =
+  def validMoves(board: Position): List[Move] =
     import board.{ genEnPassant, genNonKing, isWhiteTurn, us }
     if isWhiteTurn then genEnPassant(us & board.pawns) ++ genNonKing(~us & ~board.kings)
     else Standard.validMoves(board)
 
-  override def valid(board: Board, strict: Boolean): Boolean =
+  override def valid(board: Position, strict: Boolean): Boolean =
     board.kingOf(White).isEmpty
       && validSide(board, strict)(Black)
       && !pawnsOnPromotionRank(board, White)
       && (!strict || board.color.white || Standard.hasValidCheckers(board))
 
   /** The game has a special end condition when black manages to capture all of white's pawns */
-  override def specialEnd(board: Board): Boolean =
+  override def specialEnd(board: Position): Boolean =
     board.white.isEmpty
 
   /** Any vs K + any where horde is stalemated and only king can move is a fortress draw
     * This does not consider imminent fortresses such as 8/p7/P7/8/8/P7/8/k7 b - -
     * nor does it consider contrived fortresses such as b7/pk6/P7/P7/8/8/8/8 b - -
     */
-  private def hordeClosedPosition(board: Board): Boolean =
+  private def hordeClosedPosition(board: Position): Boolean =
     val hordeSquare = board.byColor(White)
     val mateInOne = hordeSquare.count == 1 &&
       hordeSquare.singleSquare.exists(pieceThreatened(board, Color.black, _))
@@ -69,7 +69,7 @@ case object Horde
   /** In horde chess, black can win unless a fortress stalemate is unavoidable.
     *  Auto-drawing the game should almost never happen, but it did in https://lichess.org/xQ2RsU8N#121
     */
-  override def isInsufficientMaterial(board: Board): Boolean =
+  override def isInsufficientMaterial(board: Position): Boolean =
     Color.all.forall(color => hordeClosedPosition(board.copy(color = color)))
 
   /** In horde chess, the horde cannot win on * v K or [BN]{2} v K or just one piece
@@ -77,15 +77,15 @@ case object Horde
     * Technically there are some positions where stalemate is unavoidable which
     * this method does not detect; however, such are trivial to premove.
     */
-  override def opponentHasInsufficientMaterial(board: Board): Boolean =
+  override def opponentHasInsufficientMaterial(board: Position): Boolean =
     hasInsufficientMaterial(board, !board.color) || hordeClosedPosition(board)
 
-  extension (board: Board)
+  extension (board: Position)
     def hasBishopPair: Color => Boolean = side =>
       val bishops = board.bishops & board.byColor(side)
       bishops.intersects(Bitboard.lightSquares) && bishops.intersects(Bitboard.darkSquares)
 
-  def hasInsufficientMaterial(board: Board, color: Color): Boolean =
+  def hasInsufficientMaterial(board: Position, color: Color): Boolean =
     import SquareColor.*
     import Bitboard.*
     // Black can always win by capturing the horde

--- a/core/src/main/scala/variant/Horde.scala
+++ b/core/src/main/scala/variant/Horde.scala
@@ -86,7 +86,6 @@ case object Horde
 
   def hasInsufficientMaterial(board: Position, color: Color): Boolean =
     import SquareColor.*
-    import Bitboard.*
     // Black can always win by capturing the horde
     if color.black then false
     else

--- a/core/src/main/scala/variant/Horde.scala
+++ b/core/src/main/scala/variant/Horde.scala
@@ -2,8 +2,7 @@ package chess
 package variant
 
 import cats.syntax.all.*
-import chess.bitboard.Bitboard
-import chess.bitboard.Bitboard.*
+import chess.Bitboard.*
 import chess.format.FullFen
 
 case object Horde

--- a/core/src/main/scala/variant/KingOfTheHill.scala
+++ b/core/src/main/scala/variant/KingOfTheHill.scala
@@ -17,9 +17,10 @@ case object KingOfTheHill
   def validMoves(board: Position): List[Move] =
     Standard.validMoves(board)
 
-  override def valid(board: Position, strict: Boolean): Boolean = Standard.valid(board, strict)
+  override def valid(board: Position, strict: Boolean): Boolean =
+    Standard.valid(board, strict)
 
-  override def specialEnd(board: Position) =
+  override def specialEnd(board: Position): Boolean =
     board.kingOf(!board.color).intersects(Bitboard.center)
 
   /** You only need a king to be able to win in this variant

--- a/core/src/main/scala/variant/KingOfTheHill.scala
+++ b/core/src/main/scala/variant/KingOfTheHill.scala
@@ -20,7 +20,7 @@ case object KingOfTheHill
   override def valid(board: Position, strict: Boolean): Boolean = Standard.valid(board, strict)
 
   override def specialEnd(board: Position) =
-    board.kingOf(!board.color).intersects(bitboard.Bitboard.center)
+    board.kingOf(!board.color).intersects(Bitboard.center)
 
   /** You only need a king to be able to win in this variant
     */

--- a/core/src/main/scala/variant/KingOfTheHill.scala
+++ b/core/src/main/scala/variant/KingOfTheHill.scala
@@ -14,15 +14,15 @@ case object KingOfTheHill
 
   def pieces = Standard.pieces
 
-  def validMoves(board: Board): List[Move] =
+  def validMoves(board: Position): List[Move] =
     Standard.validMoves(board)
 
-  override def valid(board: Board, strict: Boolean): Boolean = Standard.valid(board, strict)
+  override def valid(board: Position, strict: Boolean): Boolean = Standard.valid(board, strict)
 
-  override def specialEnd(board: Board) =
+  override def specialEnd(board: Position) =
     board.kingOf(!board.color).intersects(bitboard.Bitboard.center)
 
   /** You only need a king to be able to win in this variant
     */
-  override def opponentHasInsufficientMaterial(board: Board): Boolean = false
-  override def isInsufficientMaterial(board: Board): Boolean          = false
+  override def opponentHasInsufficientMaterial(board: Position): Boolean = false
+  override def isInsufficientMaterial(board: Position): Boolean          = false

--- a/core/src/main/scala/variant/RacingKings.scala
+++ b/core/src/main/scala/variant/RacingKings.scala
@@ -44,19 +44,19 @@ case object RacingKings
 
   override val initialFen = FullFen("8/8/8/8/8/8/krbnNBRK/qrbnNBRQ w - - 0 1")
 
-  def validMoves(board: Board): List[Move] =
+  def validMoves(board: Position): List[Move] =
     import board.{ genSafeKing, genNonKingAndNonPawn, us }
     val targets = ~us
     val moves   = genNonKingAndNonPawn(targets) ++ genSafeKing(targets)
     moves.filter(kingSafety)
 
-  override def valid(board: Board, strict: Boolean): Boolean =
+  override def valid(board: Position, strict: Boolean): Boolean =
     super.valid(board, strict) && (!strict || board.check.no)
 
-  override def isInsufficientMaterial(board: Board)          = false
-  override def opponentHasInsufficientMaterial(board: Board) = false
+  override def isInsufficientMaterial(board: Position)          = false
+  override def opponentHasInsufficientMaterial(board: Position) = false
 
-  private def reachedGoal(board: Board, color: Color) =
+  private def reachedGoal(board: Position, color: Color) =
     board.kingOf(color).intersects(Bitboard.rank(Rank.Eighth))
 
   private def reachesGoal(move: Move) =
@@ -66,7 +66,7 @@ case object RacingKings
   // the goal and black can make it on the next ply, he is given a chance to
   // draw, to compensate for the first-move advantage. The draw is not called
   // automatically, because black should also be given equal chances to flag.
-  override def specialEnd(board: Board) =
+  override def specialEnd(board: Position) =
     board.color match
       case White =>
         reachedGoal(board, White) ^ reachedGoal(board, Black)
@@ -75,10 +75,10 @@ case object RacingKings
 
   // If white reaches the goal and black also reaches the goal directly after,
   // then it is a draw.
-  override def specialDraw(board: Board) =
+  override def specialDraw(board: Position) =
     board.color.white && reachedGoal(board, White) && reachedGoal(board, Black)
 
-  override def winner(board: Board): Option[Color] =
+  override def winner(board: Position): Option[Color] =
     specialEnd(board).option(Color.fromWhite(reachedGoal(board, White)))
 
   // Not only check that our king is safe,
@@ -87,5 +87,5 @@ case object RacingKings
     super.kingSafety(m) && m.after.isCheck(!m.color).no
 
   // When considering stalemate, take into account that checks are not allowed.
-  override def staleMate(board: Board): Boolean =
+  override def staleMate(board: Position): Boolean =
     board.check.no && !specialEnd(board) && board.legalMoves.isEmpty

--- a/core/src/main/scala/variant/RacingKings.scala
+++ b/core/src/main/scala/variant/RacingKings.scala
@@ -3,8 +3,6 @@ package variant
 
 import chess.format.FullFen
 
-import bitboard.Bitboard
-
 case object RacingKings
     extends Variant(
       id = Variant.Id(9),

--- a/core/src/main/scala/variant/Standard.scala
+++ b/core/src/main/scala/variant/Standard.scala
@@ -17,7 +17,7 @@ case object Standard
 
   val pieces: Map[Square, Piece] = Variant.symmetricRank(backRank)
 
-  def validMoves(board: Board): List[Move] =
+  def validMoves(board: Position): List[Move] =
     import board.{ genNonKing, genSafeKing, genCastling, color, ourKing }
     val enPassantMoves = board.genEnPassant(board.us & board.pawns)
     ourKing.fold(Nil): king =>
@@ -33,7 +33,7 @@ case object Standard
       else candidates
 
   // Used for filtering candidate moves that would leave put the king in check.
-  def isSafe(board: Board, king: Square, blockers: Bitboard)(move: Move): Boolean =
+  def isSafe(board: Position, king: Square, blockers: Bitboard)(move: Move): Boolean =
     import board.{ us, them }
     if move.enpassant then
       val newOccupied = (board.occupied ^ move.orig.bl ^ move.dest.withRankOf(move.orig).bl) | move.dest.bl
@@ -43,7 +43,7 @@ case object Standard
       !(us & blockers).contains(move.orig) || Bitboard.aligned(move.orig, move.dest, king)
     else true
 
-  private def genEvasions(king: Square, board: Board, checkers: Bitboard): List[Move] =
+  private def genEvasions(king: Square, board: Position, checkers: Bitboard): List[Move] =
     import board.{ genNonKing, genSafeKing, us }
     // Checks by these sliding pieces can maybe be blocked.
     val sliders   = checkers & board.sliders
@@ -52,16 +52,16 @@ case object Standard
     val blockers  = checkers.singleSquare.fold(Nil)(c => genNonKing(Bitboard.between(king, c) | checkers))
     safeKings ++ blockers
 
-  override def valid(board: Board, strict: Boolean): Boolean =
+  override def valid(board: Position, strict: Boolean): Boolean =
     super.valid(board, strict) && (!strict || hasValidCheckers(board))
 
-  def hasValidCheckers(board: Board): Boolean =
+  def hasValidCheckers(board: Position): Boolean =
     board.checkers.isEmpty || {
       isValidChecksForMultipleCheckers(board, board.checkers) &&
       isValidCheckersForEnPassant(board, board.checkers)
     }
 
-  private def isValidCheckersForEnPassant(board: Board, activeCheckers: Bitboard): Boolean =
+  private def isValidCheckersForEnPassant(board: Position, activeCheckers: Bitboard): Boolean =
     (for
       enPassantSquare <- board.potentialEpSquare
       enPassantUp     <- board.color.fold(enPassantSquare.down, enPassantSquare.up)
@@ -73,7 +73,7 @@ case object Standard
         .exists(previousBoard => board.ourKing.exists(previousBoard.attackers(_, !board.color).isEmpty))
     )).getOrElse(true)
 
-  private def isValidChecksForMultipleCheckers(board: Board, activeCheckers: Bitboard): Boolean =
+  private def isValidChecksForMultipleCheckers(board: Position, activeCheckers: Bitboard): Boolean =
     val checkerCount = activeCheckers.count
     if checkerCount <= 1 then true
     else if checkerCount >= 3 then false

--- a/core/src/main/scala/variant/Standard.scala
+++ b/core/src/main/scala/variant/Standard.scala
@@ -1,8 +1,6 @@
 package chess
 package variant
 
-import Bitboard.*
-
 case object Standard
     extends Variant(
       id = Variant.Id(1),

--- a/core/src/main/scala/variant/Standard.scala
+++ b/core/src/main/scala/variant/Standard.scala
@@ -1,8 +1,7 @@
 package chess
 package variant
 
-import bitboard.Bitboard
-import bitboard.Bitboard.*
+import Bitboard.*
 
 case object Standard
     extends Variant(

--- a/core/src/main/scala/variant/Standard.scala
+++ b/core/src/main/scala/variant/Standard.scala
@@ -65,7 +65,7 @@ case object Standard
       enPassantDown   <- board.color.fold(enPassantSquare.up, enPassantSquare.down)
       ourKing         <- board.ourKing
     yield activeCheckers.count == 1 && (
-      activeCheckers.first.contains(enPassantSquare) || board
+      activeCheckers.first.contains(enPassantSquare) || board.board
         .move(enPassantUp, enPassantDown)
         .exists(previousBoard => board.ourKing.exists(previousBoard.attackers(_, !board.color).isEmpty))
     )).getOrElse(true)

--- a/core/src/main/scala/variant/ThreeCheck.scala
+++ b/core/src/main/scala/variant/ThreeCheck.scala
@@ -18,16 +18,16 @@ case object ThreeCheck
 
   override val initialFen = FullFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 +0+0")
 
-  def validMoves(board: Board): List[Move] =
+  def validMoves(board: Position): List[Move] =
     Standard.validMoves(board)
 
-  override def valid(board: Board, strict: Boolean): Boolean = Standard.valid(board, strict)
+  override def valid(board: Position, strict: Boolean): Boolean = Standard.valid(board, strict)
 
-  override def finalizeBoard(board: Board, uci: format.Uci, capture: Option[Piece]): Board =
+  override def finalizeBoard(board: Position, uci: format.Uci, capture: Option[Piece]): Position =
     board.updateHistory:
       _.withCheck(Color.White, checkWhite(board.board)).withCheck(Color.Black, checkBlack(board.board))
 
-  override def specialEnd(board: Board) =
+  override def specialEnd(board: Position) =
     board.check.yes && {
       val checks = board.history.checkCount
       board.color.fold(checks.white, checks.black) >= 3
@@ -35,9 +35,9 @@ case object ThreeCheck
 
   /** It's not possible to check or checkmate the opponent with only a king
     */
-  override def opponentHasInsufficientMaterial(board: Board) =
+  override def opponentHasInsufficientMaterial(board: Position) =
     board.kingsOnlyOf(!board.color)
 
   // When there is insufficient mating material, there is still potential to win by checking the opponent 3 times
   // by the variant ending. However, no players can check if there are only kings remaining
-  override def isInsufficientMaterial(board: Board) = board.kingsOnly
+  override def isInsufficientMaterial(board: Position) = board.kingsOnly

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -3,7 +3,7 @@ package variant
 
 import cats.Eq
 import cats.syntax.all.*
-import chess.bitboard.{ Bitboard, Board as BBoard }
+import chess.bitboard.{ Bitboard, Board }
 import chess.format.Fen
 
 // Correctness depends on singletons for each variant ID
@@ -55,13 +55,13 @@ abstract class Variant private[variant] (
   def pieceThreatened(board: Position, by: Color, to: Square): Boolean =
     board.attacks(to, by)
 
-  def kingThreatened(board: BBoard, color: Color): Check =
+  def kingThreatened(board: Board, color: Color): Check =
     board.isCheck(color)
 
-  def checkWhite(board: BBoard): Check = kingThreatened(board, White)
-  def checkBlack(board: BBoard): Check = kingThreatened(board, Black)
+  def checkWhite(board: Board): Check = kingThreatened(board, White)
+  def checkBlack(board: Board): Check = kingThreatened(board, Black)
 
-  def checkColor(board: BBoard): Option[Color] =
+  def checkColor(board: Board): Option[Color] =
     checkWhite(board).yes.option(White).orElse(checkBlack(board).yes.option(Black))
 
   def kingSafety(m: Move): Boolean =

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -3,7 +3,6 @@ package variant
 
 import cats.Eq
 import cats.syntax.all.*
-import chess.bitboard.Bitboard
 import chess.format.Fen
 
 // Correctness depends on singletons for each variant ID

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -3,7 +3,7 @@ package variant
 
 import cats.Eq
 import cats.syntax.all.*
-import chess.bitboard.{ Bitboard, Board }
+import chess.bitboard.Bitboard
 import chess.format.Fen
 
 // Correctness depends on singletons for each variant ID

--- a/playJson/src/main/scala/Json.scala
+++ b/playJson/src/main/scala/Json.scala
@@ -1,7 +1,6 @@
 package chess
 package json
 
-import chess.bitboard.Bitboard
 import chess.format.pgn.{ Glyph, Glyphs }
 import chess.format.{ Uci, UciCharPair }
 import chess.opening.Opening

--- a/test-kit/src/main/scala/chess/CoreArbitraries.scala
+++ b/test-kit/src/main/scala/chess/CoreArbitraries.scala
@@ -1,6 +1,5 @@
 package chess
 
-import chess.bitboard.Bitboard
 import chess.format.pgn.{ Glyph, Glyphs }
 import chess.format.{ Uci, UciCharPair }
 import chess.variant.{ Crazyhouse, Variant }

--- a/test-kit/src/test/scala/AtomicVariantTest.scala
+++ b/test-kit/src/test/scala/AtomicVariantTest.scala
@@ -191,7 +191,7 @@ class AtomicVariantTest extends ChessTest:
       .assertRight: game =>
         assertEquals(game.board(Square.E6), None)
         // Every piece surrounding the en-passant destination square that is not a pawn should be empty
-        import bitboard.Bitboard.*
+        import Bitboard.*
         assert:
           Square.E6.kingAttacks.forall: square =>
             game.board(square).isEmpty || square == Square.E7 || square == Square.D7

--- a/test-kit/src/test/scala/AtomicVariantTest.scala
+++ b/test-kit/src/test/scala/AtomicVariantTest.scala
@@ -191,7 +191,6 @@ class AtomicVariantTest extends ChessTest:
       .assertRight: game =>
         assertEquals(game.board(Square.E6), None)
         // Every piece surrounding the en-passant destination square that is not a pawn should be empty
-        import Bitboard.*
         assert:
           Square.E6.kingAttacks.forall: square =>
             game.board(square).isEmpty || square == Square.E7 || square == Square.D7

--- a/test-kit/src/test/scala/CastlingKingSideTest.scala
+++ b/test-kit/src/test/scala/CastlingKingSideTest.scala
@@ -31,7 +31,7 @@ RQK   R """.chess960.updateHistory(_ => castleHistory(White, kingSide = true, qu
 PPPPPPPP
 R  Q RK """
     )
-    val board: Board = """
+    val board: Position = """
    PPPPP
 B     KR""".chess960
     val g2 = Game(board)
@@ -43,12 +43,12 @@ B     KR""".chess960
 B    RK """
     )
   test("chess960 close kingside with 2 rooks around"):
-    val board: Board = """
+    val board: Position = """
 PPPPPPPP
 RKRBB   """.chess960
     assertEquals(board.destsFrom(B1), Set())
   test("chess960 close queenside"):
-    val board: Board = """
+    val board: Position = """
 PPPPPPPP
 RK     B""".chess960
     val game = Game(board)

--- a/test-kit/src/test/scala/CastlingTest.scala
+++ b/test-kit/src/test/scala/CastlingTest.scala
@@ -12,7 +12,7 @@ class CastlingTest extends ChessTest:
 
   import compare.dests
 
-  val board: Board = """R   K  R"""
+  val board: Position = """R   K  R"""
 
   test("threat on king prevents castling: by a rook"):
     assertEquals(
@@ -27,30 +27,30 @@ class CastlingTest extends ChessTest:
     assertEquals(board.place(Black.bishop, A5).flatMap(_.destsFrom(E1)), Set(D1, E2, F2, F1))
 
   test("threat on castle trip prevents castling: king side"):
-    val board: Board = """R  QK  R"""
+    val board: Position = """R  QK  R"""
     assertEquals(board.place(Black.rook, F3).flatMap(_.destsFrom(E1)), Set(D2, E2))
     assertEquals(board.place(Black.rook, G3).flatMap(_.destsFrom(E1)), Set(D2, E2, F2, F1))
 
   test("threat on castle trip prevents castling: queen side"):
-    val board: Board = """R   KB R"""
+    val board: Position = """R   KB R"""
     assertEquals(board.place(Black.rook, D3).flatMap(_.destsFrom(E1)), Set(E2, F2))
     assertEquals(board.place(Black.rook, C3).flatMap(_.destsFrom(E1)), Set(D1, D2, E2, F2))
 
   test("threat on castle trip prevents castling: chess 960"):
-    val board: Board = """BK     R"""
+    val board: Position = """BK     R"""
     assertEquals(board.place(Black.rook, F3).flatMap(_.destsFrom(B1)), Set(A2, B2, C2, C1))
     assertEquals(board.place(Black.king, E2).flatMap(_.destsFrom(B1)), Set(A2, B2, C2, C1))
 
   test("threat on rook does not prevent castling king side"):
-    val board: Board = """R  QK  R"""
+    val board: Position = """R  QK  R"""
     assertEquals(board.place(Black.rook, H3).flatMap(_.destsFrom(E1)), Set(D2, E2, F1, F2, G1, H1))
 
   test("threat on rook does not prevent castling queen side"):
-    val board: Board = """R   KB R"""
+    val board: Position = """R   KB R"""
     assertEquals(board.place(Black.rook, A3).flatMap(_.destsFrom(E1)), Set(A1, C1, D1, D2, E2, F2))
 
   test("threat on rooks trip does not prevent castling queen side"):
-    val board: Board = """R   KB R"""
+    val board: Position = """R   KB R"""
     assertEquals(board.place(Black.rook, B3).flatMap(_.destsFrom(E1)), Set(A1, C1, D1, D2, E2, F2))
 
   test("unmovedRooks and castles are consistent"):

--- a/test-kit/src/test/scala/ChessTest.scala
+++ b/test-kit/src/test/scala/ChessTest.scala
@@ -8,7 +8,6 @@ import scala.language.implicitConversions
 import format.{ FullFen, Fen, Uci, Visual }
 import format.pgn.PgnStr
 import variant.{ Chess960, Variant }
-import bitboard.Board
 
 trait ChessTestCommon:
 

--- a/test-kit/src/test/scala/ChessTest.scala
+++ b/test-kit/src/test/scala/ChessTest.scala
@@ -12,23 +12,23 @@ import bitboard.Board as BBoard
 
 trait ChessTestCommon:
 
-  given Conversion[String, Board]  = Visual.<<
-  given Conversion[String, PgnStr] = PgnStr(_)
-  given Conversion[PgnStr, String] = _.value
+  given Conversion[String, Position] = Visual.<<
+  given Conversion[String, PgnStr]   = PgnStr(_)
+  given Conversion[PgnStr, String]   = _.value
 
   extension (str: String)
-    def chess960: Board         = makeBoard(str, chess.variant.Chess960)
-    def kingOfTheHill: Board    = makeBoard(str, chess.variant.KingOfTheHill)
-    def threeCheck: Board       = makeBoard(str, chess.variant.ThreeCheck)
-    def as(color: Color): Board = (Visual << str).withColor(color)
+    def chess960: Position         = makeBoard(str, chess.variant.Chess960)
+    def kingOfTheHill: Position    = makeBoard(str, chess.variant.KingOfTheHill)
+    def threeCheck: Position       = makeBoard(str, chess.variant.ThreeCheck)
+    def as(color: Color): Position = (Visual << str).withColor(color)
 
-  extension (board: Board)
+  extension (board: Position)
     def visual = Visual >> board
     def destsFrom(from: Square): Option[List[Square]] =
       board(from).map: piece =>
         board.withColor(piece.color).generateMovesAt(from).map(_.dest)
 
-    def seq(actions: Board => Option[Board]*): Option[Board] =
+    def seq(actions: Position => Option[Position]*): Option[Position] =
       actions.foldLeft(board.some)(_ flatMap _)
 
   extension (game: Game)
@@ -49,7 +49,7 @@ trait ChessTestCommon:
 
     def withClock(c: Clock) = game.copy(clock = Option(c))
 
-  extension (sit: Board)
+  extension (sit: Position)
     def movesAt(s: Square): List[Move] =
       sit.moves.getOrElse(s, Nil)
 
@@ -66,7 +66,7 @@ trait ChessTestCommon:
         Game(variant).copy(board = board.withColor(color))
       .toRight("Could not construct board from Fen")
 
-  def makeBoard(pieces: (Square, Piece)*): Board =
+  def makeBoard(pieces: (Square, Piece)*): Position =
     makeBoard(pieces.toMap, defaultHistory(), chess.variant.Standard, None, None)
 
   def makeBoard(
@@ -75,19 +75,19 @@ trait ChessTestCommon:
       variant: Variant,
       crazyData: Option[Crazyhouse.Data],
       color: Option[Color]
-  ): Board =
-    new Board(BBoard.fromMap(pieces), history.copy(crazyData = crazyData), variant, color.getOrElse(White))
+  ): Position =
+    new Position(BBoard.fromMap(pieces), history.copy(crazyData = crazyData), variant, color.getOrElse(White))
 
   def makeBoard(str: String, variant: Variant) =
     (Visual << str).withVariant(variant)
 
-  def makeBoard: Board = Board.init(chess.variant.Standard, White)
+  def makeBoard: Position = Position.init(chess.variant.Standard, White)
 
-  def makeChess960Board(position: Int) = Board(BBoard.fromMap(Chess960.pieces(position)), Chess960, None)
+  def makeChess960Board(position: Int) = Position(BBoard.fromMap(Chess960.pieces(position)), Chess960, None)
   def makeChess960Game(position: Int)  = Game(makeChess960Board(position))
   def chess960Boards                   = (0 to 959).map(makeChess960Board).toList
 
-  def makeEmptyBoard: Board = Board(BBoard.empty, chess.variant.Standard, White.some)
+  def makeEmptyBoard: Position = Position(BBoard.empty, chess.variant.Standard, White.some)
 
   def makeGame: Game = Game(makeBoard)
 
@@ -181,9 +181,9 @@ trait ChessTest extends munit.FunSuite with ChessTestCommon with MunitExtensions
   def fenToGame(positionString: FullFen, variant: Variant)(using Location): Game =
     fenToGameEither(positionString, variant).get
 
-  def visualDests(board: Board, p: Iterable[Square]): String =
+  def visualDests(board: Position, p: Iterable[Square]): String =
     Visual.addNewLines(Visual.>>|(board, Map(p -> 'x')))
-  def visualDests(board: Board, p: Option[Iterable[Square]]): String = visualDests(board, p | Nil)
+  def visualDests(board: Position, p: Option[Iterable[Square]]): String = visualDests(board, p | Nil)
 
   def assertGame(game: Game, visual: String)(using Location) =
     assertEquals(game.board.visual, (Visual << visual).visual)

--- a/test-kit/src/test/scala/ChessTest.scala
+++ b/test-kit/src/test/scala/ChessTest.scala
@@ -8,7 +8,7 @@ import scala.language.implicitConversions
 import format.{ FullFen, Fen, Uci, Visual }
 import format.pgn.PgnStr
 import variant.{ Chess960, Variant }
-import bitboard.Board as BBoard
+import bitboard.Board
 
 trait ChessTestCommon:
 
@@ -76,18 +76,18 @@ trait ChessTestCommon:
       crazyData: Option[Crazyhouse.Data],
       color: Option[Color]
   ): Position =
-    new Position(BBoard.fromMap(pieces), history.copy(crazyData = crazyData), variant, color.getOrElse(White))
+    new Position(Board.fromMap(pieces), history.copy(crazyData = crazyData), variant, color.getOrElse(White))
 
   def makeBoard(str: String, variant: Variant) =
     (Visual << str).withVariant(variant)
 
   def makeBoard: Position = Position.init(chess.variant.Standard, White)
 
-  def makeChess960Board(position: Int) = Position(BBoard.fromMap(Chess960.pieces(position)), Chess960, None)
+  def makeChess960Board(position: Int) = Position(Board.fromMap(Chess960.pieces(position)), Chess960, None)
   def makeChess960Game(position: Int)  = Game(makeChess960Board(position))
   def chess960Boards                   = (0 to 959).map(makeChess960Board).toList
 
-  def makeEmptyBoard: Position = Position(BBoard.empty, chess.variant.Standard, White.some)
+  def makeEmptyBoard: Position = Position(Board.empty, chess.variant.Standard, White.some)
 
   def makeGame: Game = Game(makeBoard)
 

--- a/test-kit/src/test/scala/ChessTest.scala
+++ b/test-kit/src/test/scala/ChessTest.scala
@@ -30,6 +30,15 @@ trait ChessTestCommon:
     def seq(actions: Position => Option[Position]*): Option[Position] =
       actions.foldLeft(board.some)(_ flatMap _)
 
+    def place(piece: Piece, at: Square): Option[Position] =
+      board.board.put(piece, at).map(board.withBoard)
+
+    def take(at: Square): Option[Position] =
+      board.board.take(at).map(board.withBoard)
+
+    def move(orig: Square, dest: Square): Option[Position] =
+      board.board.move(orig, dest).map(board.withBoard)
+
   extension (game: Game)
     def as(color: Color): Game = game.withPlayer(color)
 

--- a/test-kit/src/test/scala/CrazyhouseDataTest.scala
+++ b/test-kit/src/test/scala/CrazyhouseDataTest.scala
@@ -1,5 +1,5 @@
 package chess
-import chess.bitboard.Bitboard
+
 import chess.variant.Crazyhouse.Data
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop.{ forAll, propBoolean }

--- a/test-kit/src/test/scala/CrazyhouseVariantTest.scala
+++ b/test-kit/src/test/scala/CrazyhouseVariantTest.scala
@@ -2,7 +2,6 @@ package chess
 
 import cats.syntax.option.*
 import chess.Square.*
-import chess.bitboard.Bitboard
 import chess.format.FullFen
 import chess.format.pgn.SanStr
 import chess.variant.Crazyhouse

--- a/test-kit/src/test/scala/HashTest.scala
+++ b/test-kit/src/test/scala/HashTest.scala
@@ -60,7 +60,7 @@ class HashTest extends ChessTest:
 
   test("Hasher: account for checks in three-check"):
     // 2 ... Bb4+
-    val gameA = Game(Board.init(ThreeCheck, White))
+    val gameA = Game(Position.init(ThreeCheck, White))
       .playMoves(
         E2 -> E4,
         E7 -> E6,

--- a/test-kit/src/test/scala/HordeVariantTest.scala
+++ b/test-kit/src/test/scala/HordeVariantTest.scala
@@ -120,7 +120,7 @@ class HordeVariantTest extends ChessTest:
     assertEquals(steps.last._1.board.legalMoves.exists(_.castles), true)
 
   test("UnmovedRooks & castles at the starting position"):
-    val board = Board.init(Horde, White)
+    val board = Position.init(Horde, White)
     assertEquals(board.history.unmovedRooks, UnmovedRooks(Set(Square.A8, Square.H8)))
     assertEquals(board.history.castles, Castles(false, false, true, true))
 

--- a/test-kit/src/test/scala/InsufficientMaterialTest.scala
+++ b/test-kit/src/test/scala/InsufficientMaterialTest.scala
@@ -43,4 +43,4 @@ object InsufficientMaterialTest extends SimpleIOSuite:
 private case class Case(fen: FullFen, expected: Boolean, comment: Option[String]):
   def run(variant: Variant): Boolean =
     val board = Fen.read(variant, fen).get
-    Horde.hasInsufficientMaterial(board, !board.color) == expected
+    Horde.hasInsufficientMaterial(board.board, !board.color) == expected

--- a/test-kit/src/test/scala/UnmovedRooksTest.scala
+++ b/test-kit/src/test/scala/UnmovedRooksTest.scala
@@ -8,7 +8,7 @@ import scala.language.implicitConversions
 import Square.*
 import variant.{ Atomic, Chess960 }
 import format.FullFen
-import bitboard.{Bitboard, Board}
+import bitboard.Bitboard
 
 class UnmovedRooksTest extends ChessTest:
 

--- a/test-kit/src/test/scala/UnmovedRooksTest.scala
+++ b/test-kit/src/test/scala/UnmovedRooksTest.scala
@@ -8,8 +8,7 @@ import scala.language.implicitConversions
 import Square.*
 import variant.{ Atomic, Chess960 }
 import format.FullFen
-import bitboard.Board as BBoard
-import bitboard.Bitboard
+import bitboard.{Bitboard, Board}
 
 class UnmovedRooksTest extends ChessTest:
 
@@ -30,7 +29,7 @@ class UnmovedRooksTest extends ChessTest:
 
   test("At the start, unmovedRooks == rooks"):
     chess960Boards.map: board =>
-      assertEquals(board.history.unmovedRooks, BBoard.fromMap(board.pieces).rooks)
+      assertEquals(board.history.unmovedRooks, Board.fromMap(board.pieces).rooks)
 
   test("At the start, both sides should have two unmoved rooks"):
     chess960Boards.map: board =>

--- a/test-kit/src/test/scala/UnmovedRooksTest.scala
+++ b/test-kit/src/test/scala/UnmovedRooksTest.scala
@@ -8,7 +8,6 @@ import scala.language.implicitConversions
 import Square.*
 import variant.{ Atomic, Chess960 }
 import format.FullFen
-import bitboard.Bitboard
 
 class UnmovedRooksTest extends ChessTest:
 

--- a/test-kit/src/test/scala/VariantTest.scala
+++ b/test-kit/src/test/scala/VariantTest.scala
@@ -148,7 +148,7 @@ class VariantTest extends ChessTest:
     assertEquals(Chess960.pieces.get(A2), Some(White - Pawn))
 
   test("chess960 initialize the board with castling rights"):
-    assertEquals(Board.init(Chess960, White).history.castles, Castles.init)
+    assertEquals(Position.init(Chess960, White).history.castles, Castles.init)
 
   test("kingOfTheHill detect win"):
     val game = Game(
@@ -182,7 +182,7 @@ PP
     assertEquals(sit.winner, Some(Black))
 
   test("kingOfTheHill initialize the board with castling rights"):
-    assertEquals(Board.init(KingOfTheHill, White).history.castles, Castles.init)
+    assertEquals(Position.init(KingOfTheHill, White).history.castles, Castles.init)
 
   test("threeCheck detect win"):
     assertNot(
@@ -203,7 +203,7 @@ K  r
     assert(game.board.end)
     assertEquals(game.board.winner, Some(Black))
   test("threeCheck 1 check"):
-    val game = Game(Board.init(ThreeCheck, White))
+    val game = Game(Position.init(ThreeCheck, White))
       .playMoves(
         E2 -> E4,
         E7 -> E6,
@@ -213,7 +213,7 @@ K  r
       .get
     assertNot(game.board.end)
   test("threeCheck 2 checks"):
-    val game = Game(Board.init(ThreeCheck, White))
+    val game = Game(Position.init(ThreeCheck, White))
       .playMoves(
         E2 -> E4,
         E7 -> E6,
@@ -225,7 +225,7 @@ K  r
       .get
     assertNot(game.board.end)
   test("threeCheck 3 checks"):
-    val game = Game(Board.init(ThreeCheck, White))
+    val game = Game(Position.init(ThreeCheck, White))
       .playMoves(
         E2 -> E4,
         E7 -> E6,
@@ -256,7 +256,7 @@ K  r
     assertEquals(game.board.status, Status.Draw.some)
 
   test("threeCheck initialize the board with castling rights"):
-    assertEquals(Board.init(KingOfTheHill, White).history.castles, Castles.init)
+    assertEquals(Position.init(KingOfTheHill, White).history.castles, Castles.init)
 
   test("racingKings call it stalemate when there is no legal move"):
     val position = FullFen("8/8/8/8/3K4/8/1k6/b7 b - - 5 3")
@@ -300,7 +300,7 @@ K  r
     assertEquals(game.board.status, Status.Draw.some)
 
   test("racingKings initialize the board without castling rights"):
-    assert(Board.init(RacingKings, White).history.castles.isEmpty)
+    assert(Position.init(RacingKings, White).history.castles.isEmpty)
 
   List(
     "1bb4r/kr5p/p7/2pP4/4PK2/8/PPP3PP/RNBQ1BNR w HAh c6 0 4",
@@ -321,7 +321,7 @@ K  r
       assert(game.variant.valid(game, false))
 
   test("antichess initialize the board without castling rights"):
-    assert(Board.init(Antichess, White).history.castles.isEmpty)
+    assert(Position.init(Antichess, White).history.castles.isEmpty)
 
   test("antichess calculate material imbalance"):
     val position = FullFen("8/p7/8/8/2B5/b7/PPPK2PP/RNB3NR w - - 1 16")

--- a/test-kit/src/test/scala/bitboard/BitboardTest.scala
+++ b/test-kit/src/test/scala/bitboard/BitboardTest.scala
@@ -5,7 +5,6 @@ import munit.ScalaCheckSuite
 import org.scalacheck.Prop.{ forAll, propBoolean }
 
 import CoreArbitraries.given
-import Bitboard.*
 
 class BitboardTest extends ScalaCheckSuite:
 

--- a/test-kit/src/test/scala/bitboard/BoardTest.scala
+++ b/test-kit/src/test/scala/bitboard/BoardTest.scala
@@ -4,7 +4,6 @@ package bitboard
 import chess.format.{ Fen, FullFen }
 
 import Square.*
-import Bitboard.*
 
 class BoardTest extends ChessTest:
 

--- a/test-kit/src/test/scala/format/Visual.scala
+++ b/test-kit/src/test/scala/format/Visual.scala
@@ -3,8 +3,6 @@ package format
 
 import chess.variant.{ Crazyhouse, Variant }
 
-import bitboard.Board
-
 /** r bqkb r
   * p ppp pp
   * pr

--- a/test-kit/src/test/scala/format/Visual.scala
+++ b/test-kit/src/test/scala/format/Visual.scala
@@ -1,8 +1,9 @@
 package chess
 package format
 
-import chess.bitboard.Board as BBoard
 import chess.variant.{ Crazyhouse, Variant }
+
+import bitboard.Board
 
 /** r bqkb r
   * p ppp pp
@@ -51,7 +52,7 @@ object Visual:
   def addNewLines(str: String) = "\n" + str + "\n"
 
   def createBoard(pieces: Iterable[(Square, Piece)], variant: Variant): Position =
-    val board        = BBoard.fromMap(pieces.toMap)
+    val board        = Board.fromMap(pieces.toMap)
     val unmovedRooks = if variant.allowsCastling then UnmovedRooks(board.rooks) else UnmovedRooks.none
     Position(
       board,

--- a/test-kit/src/test/scala/format/Visual.scala
+++ b/test-kit/src/test/scala/format/Visual.scala
@@ -15,7 +15,7 @@ import chess.variant.{ Crazyhouse, Variant }
   */
 object Visual:
 
-  def <<(source: String): Board =
+  def <<(source: String): Position =
     val lines = augmentString(source).linesIterator.to(List)
     val filtered = lines.size match
       case 8          => lines
@@ -33,9 +33,9 @@ object Visual:
     )
     b.updateHistory(_ => History(unmovedRooks = UnmovedRooks.from(b), crazyData = None))
 
-  def >>(board: Board): String = >>|(board, Map.empty)
+  def >>(board: Position): String = >>|(board, Map.empty)
 
-  def >>|(board: Board, marks: Map[Iterable[Square], Char]): String = {
+  def >>|(board: Position, marks: Map[Iterable[Square], Char]): String = {
     val markedPoss: Map[Square, Char] = marks.foldLeft(Map[Square, Char]()) { case (marks, (poss, char)) =>
       marks ++ (poss.toList.map { square =>
         (square, char)
@@ -50,10 +50,10 @@ object Visual:
 
   def addNewLines(str: String) = "\n" + str + "\n"
 
-  def createBoard(pieces: Iterable[(Square, Piece)], variant: Variant): Board =
+  def createBoard(pieces: Iterable[(Square, Piece)], variant: Variant): Position =
     val board        = BBoard.fromMap(pieces.toMap)
     val unmovedRooks = if variant.allowsCastling then UnmovedRooks(board.rooks) else UnmovedRooks.none
-    Board(
+    Position(
       board,
       History(
         castles = variant.castles,

--- a/test-kit/src/test/scala/format/Visual.scala
+++ b/test-kit/src/test/scala/format/Visual.scala
@@ -20,7 +20,7 @@ object Visual:
       case 8          => lines
       case n if n > 8 => lines.slice(1, 9)
       case n          => (List.fill(8 - n)("")) ::: lines
-    val b = createBoard(
+    val p = createPosition(
       pieces = (for
         (l, y) <- filtered.zipWithIndex
         (c, x) <- l.zipWithIndex
@@ -30,7 +30,7 @@ object Visual:
       }).flatten,
       variant = chess.variant.Variant.default
     )
-    b.updateHistory(_ => History(unmovedRooks = UnmovedRooks.from(b), crazyData = None))
+    p.updateHistory(_ => History(unmovedRooks = UnmovedRooks.from(p.board), crazyData = None))
 
   def >>(board: Position): String = >>|(board, Map.empty)
 
@@ -49,7 +49,7 @@ object Visual:
 
   def addNewLines(str: String) = "\n" + str + "\n"
 
-  def createBoard(pieces: Iterable[(Square, Piece)], variant: Variant): Position =
+  def createPosition(pieces: Iterable[(Square, Piece)], variant: Variant): Position =
     val board        = Board.fromMap(pieces.toMap)
     val unmovedRooks = if variant.allowsCastling then UnmovedRooks(board.rooks) else UnmovedRooks.none
     Position(

--- a/test-kit/src/test/scala/format/pgn/DumperTest.scala
+++ b/test-kit/src/test/scala/format/pgn/DumperTest.scala
@@ -14,7 +14,7 @@ class DumperTest extends ChessTest:
 
   test("Check with pawn not be checkmate if pawn can be taken en passant"):
     val game = Fen.readWithMoveNumber(FullFen("8/3b4/6R1/1P2kp2/6pp/2N1P3/4KPPP/8 w - -")).get match
-      case s: Board.AndFullMoveNumber => Game(s.board, ply = s.ply)
+      case s: Position.AndFullMoveNumber => Game(s.board, ply = s.ply)
     val move = game(Square.F2, Square.F4).get._2
     assertEquals(Dumper(move), "f4+")
 
@@ -62,7 +62,7 @@ class DumperTest extends ChessTest:
     E2 -> A6
   )
 
-  val threeCheck = Game(Board.init(ThreeCheck, White)).playMoves(
+  val threeCheck = Game(Position.init(ThreeCheck, White)).playMoves(
     E2 -> E4,
     C7 -> C5,
     F1 -> C4,

--- a/test-kit/src/test/scala/format/pgn/ParserCheck.scala
+++ b/test-kit/src/test/scala/format/pgn/ParserCheck.scala
@@ -10,20 +10,20 @@ import ChessTreeArbitraries.*
 class ParserCheck extends ScalaCheckSuite:
 
   test("parse >>= render == identity"):
-    forAll(genPgn(Board(Standard))): pgn =>
+    forAll(genPgn(Position(Standard))): pgn =>
       val str    = pgn.render
       val result = Parser.full(str).toOption.get.toPgn.render
       assertEquals(result, str)
 
   test("mainline == full.mainlineWithMetas"):
-    forAll(genPgn(Board(Standard))): pgn =>
+    forAll(genPgn(Position(Standard))): pgn =>
       val str      = pgn.render
       val expected = Parser.full(str).toOption.map(_.mainlineWithMetas)
       val mainline = Parser.mainlineWithMetas(str).toOption.map(_.sans)
       assertEquals(mainline, expected)
 
   test("mainlineWithSan == full.mainline"):
-    forAll(genPgn(Board(Standard))): pgn =>
+    forAll(genPgn(Position(Standard))): pgn =>
       val str      = pgn.render
       val expected = Parser.full(str).toOption.map(_.mainline)
       val mainline = Parser.mainline(str).toOption.map(_.sans)

--- a/test-kit/src/test/scala/perft/Perft.scala
+++ b/test-kit/src/test/scala/perft/Perft.scala
@@ -51,7 +51,7 @@ object Perft:
     builder.append("\n").append(sum)
     println(builder)
 
-  extension (s: Board)
+  extension (s: Position)
 
     def divide(depth: Int): List[DivideResult] =
       if depth == 0 then Nil


### PR DESCRIPTION
Rename & some other small refactors

- `chess.Board` -> `chess.Position`
- `chess.Bitboard.Board` -> `chess.Board`
- `chess.bitboard.BitBoard`  -> `chess.Bitboard`