### PR TITLE
Remove variant.finalizeBoard

### DIFF
--- a/core/src/main/scala/History.scala
+++ b/core/src/main/scala/History.scala
@@ -27,25 +27,25 @@ case class History(
     crazyData: Option[Crazyhouse.Data]
 ):
 
-  def setHalfMoveClock(v: HalfMoveClock) = copy(halfMoveClock = v)
+  def setHalfMoveClock(v: HalfMoveClock): History = copy(halfMoveClock = v)
 
-  inline def threefoldRepetition = positionHashes.isRepetition(3)
-  inline def fivefoldRepetition  = positionHashes.isRepetition(5)
+  inline def threefoldRepetition: Boolean = positionHashes.isRepetition(3)
+  inline def fivefoldRepetition: Boolean  = positionHashes.isRepetition(5)
 
-  inline def canCastle(inline color: Color)                    = castles.can(color)
-  inline def canCastle(inline color: Color, inline side: Side) = castles.can(color, side)
+  inline def canCastle(inline color: Color): Boolean                    = castles.can(color)
+  inline def canCastle(inline color: Color, inline side: Side): Boolean = castles.can(color, side)
 
-  inline def withoutCastles(inline color: Color) = copy(castles = castles.without(color))
+  inline def withoutCastles(inline color: Color): History = copy(castles = castles.without(color))
 
-  inline def withoutAnyCastles = copy(castles = Castles.none)
+  inline def withoutAnyCastles: History = copy(castles = Castles.none)
 
-  inline def withoutCastle(color: Color, side: Side) = copy(castles = castles.without(color, side))
+  inline def withoutCastle(color: Color, side: Side): History = copy(castles = castles.without(color, side))
 
-  inline def withCastles(inline c: Castles) = copy(castles = c)
+  inline def withCastles(inline c: Castles): History = copy(castles = c)
 
-  inline def withLastMove(inline m: Uci) = copy(lastMove = Option(m))
+  inline def withLastMove(inline m: Uci): History = copy(lastMove = Option(m))
 
-  def withCheck(color: Color, check: Check) =
+  def withCheck(color: Color, check: Check): History =
     if check.yes then copy(checkCount = checkCount.add(color)) else this
 
-  def withCheckCount(cc: CheckCount) = copy(checkCount = cc)
+  def withCheckCount(cc: CheckCount): History = copy(checkCount = cc)

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -115,33 +115,32 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
   lazy val checkers: Bitboard       = ourKing.fold(Bitboard.empty)(board.attackers(_, !color))
 
   def generateMovesAt(square: Square): List[Move] =
-    def movesAt =
-      val moves = board.pieceAt(square).fold(Nil) { piece =>
-        if piece.color != color then Nil
-        else
-          val targets = ~us
-          val bb      = square.bb
-          piece.role match
-            case Pawn   => genEnPassant(us & bb) ++ genPawn(bb, targets)
-            case Knight => genKnight(us & bb, targets)
-            case Bishop => genBishop(us & bb, targets)
-            case Rook   => genRook(us & bb, targets)
-            case Queen  => genQueen(us & bb, targets)
-            case King   => genKingAt(targets, square)
-      }
+    val moves = board.pieceAt(square).fold(Nil) { piece =>
+      if piece.color != color then Nil
+      else
+        val targets = ~us
+        val bb      = square.bb
+        piece.role match
+          case Pawn   => genEnPassant(us & bb) ++ genPawn(bb, targets)
+          case Knight => genKnight(us & bb, targets)
+          case Bishop => genBishop(us & bb, targets)
+          case Rook   => genRook(us & bb, targets)
+          case Queen  => genQueen(us & bb, targets)
+          case King   => genKingAt(targets, square)
+    }
 
-      if variant.atomic then moves.map(Atomic.explodeSurroundingPieces).filter(variant.kingSafety)
-      else moves.filter(variant.kingSafety)
-
-    // in antichess, if there are capture moves, only capture moves are allowed
-    // so, we have to find all captures first,
-    // if they're not empty then filter by orig
-    // else use the normal moveAt
-    if variant.antichess then
+    if variant.atomic then moves.map(Atomic.explodeSurroundingPieces).filter(variant.kingSafety)
+    else if variant.crazyhouse then moves.map(Crazyhouse.updateCrazyData).filter(variant.kingSafety)
+    else if variant.threeCheck then moves.map(ThreeCheck.updateCheckCount).filter(variant.kingSafety)
+    else if variant.antichess then
+      // in antichess, if there are capture moves, only capture moves are allowed
+      // so, we have to find all captures first,
+      // if they're not empty then filter by orig
+      // else use the normal moveAt
       val captureMoves = Antichess.captureMoves(this)
       if captureMoves.nonEmpty then captureMoves.filter(_.orig == square)
-      else movesAt
-    else movesAt
+      else moves
+    else moves.filter(variant.kingSafety)
 
   def genKingAt(mask: Bitboard, square: Square) =
     val withoutCastles = genUnsafeKing(square, mask)

--- a/core/src/main/scala/variant/Antichess.scala
+++ b/core/src/main/scala/variant/Antichess.scala
@@ -31,7 +31,12 @@ case object Antichess
     if capturingMoves.nonEmpty then capturingMoves
     else genNonKing(~position.occupied) ++ ourKings.flatMap(genUnsafeKing(_, ~position.occupied))
 
-  def captureMoves(position: Position): List[Move] =
+  override def validMovesAt(position: Position, square: Square): List[Move] =
+    val captures = captureMoves(position)
+    if captures.nonEmpty then captures.filter(_.orig == square)
+    else super.validMovesAt(position, square)
+
+  private def captureMoves(position: Position): List[Move] =
     import position.{ them, us, genNonKing, genEnPassant, genUnsafeKing, ourKings }
     ourKings.flatMap(genUnsafeKing(_, them)) ++ genEnPassant(us & position.pawns) ++ genNonKing(them)
 

--- a/core/src/main/scala/variant/Atomic.scala
+++ b/core/src/main/scala/variant/Atomic.scala
@@ -20,6 +20,9 @@ case object Atomic
     val moves   = genNonKing(targets) ++ genKing(position, targets) ++ genEnPassant(us & position.pawns)
     moves.map(explodeSurroundingPieces).filter(kingSafety)
 
+  override def validMovesAt(position: Position, square: Square): List[Move] =
+    super.validMovesAt(position, square).map(explodeSurroundingPieces).filter(kingSafety)
+
   private def genKing(position: Position, mask: Bitboard) =
     import position.{ genUnsafeKing, genCastling }
     position.ourKing.fold(Nil): king =>
@@ -63,7 +66,7 @@ case object Atomic
       attackersWithoutKing(board, occupied, king, !color).isEmpty
 
   /** If the move captures, we explode the surrounding pieces. Otherwise, nothing explodes. */
-  def explodeSurroundingPieces(move: Move): Move =
+  private def explodeSurroundingPieces(move: Move): Move =
     if move.captures then
       val afterBoard = move.after
       // Pawns are immune (for some reason), but all pieces surrounding the captured piece and the capturing piece

--- a/core/src/main/scala/variant/Chess960.scala
+++ b/core/src/main/scala/variant/Chess960.scala
@@ -17,6 +17,9 @@ case object Chess960
   override def validMoves(position: Position): List[Move] =
     Standard.validMoves(position)
 
+  override def validMovesAt(position: Position, square: Square): List[Move] =
+    super.validMovesAt(position, square).filter(kingSafety)
+
   override def valid(position: Position, strict: Boolean): Boolean = Standard.valid(position, strict)
 
   override def pieces = pieces(scala.util.Random.nextInt(960))

--- a/core/src/main/scala/variant/Crazyhouse.scala
+++ b/core/src/main/scala/variant/Crazyhouse.scala
@@ -22,6 +22,9 @@ case object Crazyhouse
   override def validMoves(position: Position): List[Move] =
     Standard.validMoves(position).map(updateCrazyData)
 
+  override def validMovesAt(position: Position, square: Square): List[Move] =
+    super.validMovesAt(position, square).filter(kingSafety).map(updateCrazyData)
+
   override def valid(position: Position, strict: Boolean): Boolean =
     Color.all.forall(validSide(position, false)) &&
       (!strict ||
@@ -58,7 +61,7 @@ case object Crazyhouse
 
   override def isIrreversible(move: Move): Boolean = move.castles
 
-  def updateCrazyData(move: Move): Move =
+  private def updateCrazyData(move: Move): Move =
     val after = move.after.crazyData.fold(move.after): data =>
       val d1 = move.capture.flatMap(move.boardBefore.pieceAt).fold(data)(data.store(_, move.dest))
       val d2 = move.promotion.fold(d1.move(move.orig, move.dest))(_ => d1.promote(move.dest))

--- a/core/src/main/scala/variant/FromPosition.scala
+++ b/core/src/main/scala/variant/FromPosition.scala
@@ -16,3 +16,6 @@ case object FromPosition
 
   override def validMoves(position: Position): List[Move] =
     Standard.validMoves(position)
+
+  override def validMovesAt(position: Position, square: Square): List[Move] =
+    super.validMovesAt(position, square).filter(kingSafety)

--- a/core/src/main/scala/variant/Horde.scala
+++ b/core/src/main/scala/variant/Horde.scala
@@ -38,6 +38,9 @@ case object Horde
     if isWhiteTurn then genEnPassant(us & position.pawns) ++ genNonKing(~us & ~position.kings)
     else Standard.validMoves(position)
 
+  override def validMovesAt(position: Position, square: Square): List[Move] =
+    super.validMovesAt(position, square).filter(kingSafety)
+
   override def valid(position: Position, strict: Boolean): Boolean =
     position.kingOf(White).isEmpty
       && validSide(position, strict)(Black)

--- a/core/src/main/scala/variant/KingOfTheHill.scala
+++ b/core/src/main/scala/variant/KingOfTheHill.scala
@@ -17,6 +17,9 @@ case object KingOfTheHill
   override def validMoves(position: Position): List[Move] =
     Standard.validMoves(position)
 
+  override def validMovesAt(position: Position, square: Square): List[Move] =
+    super.validMovesAt(position, square).filter(kingSafety)
+
   override def valid(position: Position, strict: Boolean): Boolean =
     Standard.valid(position, strict)
 

--- a/core/src/main/scala/variant/RacingKings.scala
+++ b/core/src/main/scala/variant/RacingKings.scala
@@ -47,6 +47,9 @@ case object RacingKings
     val moves   = genNonKingAndNonPawn(targets) ++ genSafeKing(targets)
     moves.filter(kingSafety)
 
+  override def validMovesAt(position: Position, square: Square): List[Move] =
+    super.validMovesAt(position, square).filter(kingSafety)
+
   override def valid(position: Position, strict: Boolean): Boolean =
     super.valid(position, strict) && (!strict || position.check.no)
 

--- a/core/src/main/scala/variant/Standard.scala
+++ b/core/src/main/scala/variant/Standard.scala
@@ -32,6 +32,9 @@ case object Standard
         candidates.filter(isSafe(position, king, sliderBlockers))
       else candidates
 
+  override def validMovesAt(position: Position, square: Square): List[Move] =
+    super.validMovesAt(position, square).filter(kingSafety)
+
   // Used for filtering candidate moves that would leave put the king in check.
   def isSafe(position: Position, king: Square, blockers: Bitboard)(move: Move): Boolean =
     import position.{ us, them }

--- a/core/src/main/scala/variant/ThreeCheck.scala
+++ b/core/src/main/scala/variant/ThreeCheck.scala
@@ -21,9 +21,12 @@ case object ThreeCheck
   override def validMoves(position: Position): List[Move] =
     Standard.validMoves(position).map(updateCheckCount)
 
+  override def validMovesAt(position: Position, square: Square): List[Move] =
+    super.validMovesAt(position, square).filter(kingSafety).map(updateCheckCount)
+
   override def valid(position: Position, strict: Boolean): Boolean = Standard.valid(position, strict)
 
-  def updateCheckCount(move: Move): Move =
+  private def updateCheckCount(move: Move): Move =
     move.copy(after = move.after.updateHistory:
       _.withCheck(Color.White, checkWhite(move.after.board))
         .withCheck(Color.Black, checkBlack(move.after.board)))

--- a/core/src/main/scala/variant/ThreeCheck.scala
+++ b/core/src/main/scala/variant/ThreeCheck.scala
@@ -19,13 +19,14 @@ case object ThreeCheck
   override val initialFen: FullFen = FullFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 +0+0")
 
   override def validMoves(position: Position): List[Move] =
-    Standard.validMoves(position)
+    Standard.validMoves(position).map(updateCheckCount)
 
   override def valid(position: Position, strict: Boolean): Boolean = Standard.valid(position, strict)
 
-  override def finalizeBoard(position: Position, uci: format.Uci, capture: Option[Piece]): Position =
-    position.updateHistory:
-      _.withCheck(Color.White, checkWhite(position.board)).withCheck(Color.Black, checkBlack(position.board))
+  def updateCheckCount(move: Move): Move =
+    move.copy(after = move.after.updateHistory:
+      _.withCheck(Color.White, checkWhite(move.after.board))
+        .withCheck(Color.Black, checkBlack(move.after.board)))
 
   override def specialEnd(position: Position): Boolean =
     position.check.yes && {

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -142,10 +142,6 @@ abstract class Variant private[variant] (
   def isIrreversible(move: Move): Boolean =
     (move.piece.is(Pawn)) || move.captures || move.promotes || move.castles
 
-  /** Once a move has been decided upon from the available legal moves, the board is finalized
-    */
-  def finalizeBoard(position: Position, uci: format.Uci, captured: Option[Piece]): Position = position
-
   protected def pawnsOnPromotionRank(board: Board, color: Color): Boolean =
     board.byPiece(color, Pawn).intersects(Bitboard.rank(color.promotablePawnRank))
 

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -51,6 +51,22 @@ abstract class Variant private[variant] (
 
   def validMoves(position: Position): List[Move]
 
+  def validMovesAt(position: Position, square: Square): List[Move] =
+    import position.us
+    position.pieceAt(square).fold(Nil) { piece =>
+      if piece.color != position.color then Nil
+      else
+        val targets = ~us
+        val bb      = square.bb
+        piece.role match
+          case Pawn   => position.genEnPassant(us & bb) ++ position.genPawn(bb, targets)
+          case Knight => position.genKnight(us & bb, targets)
+          case Bishop => position.genBishop(us & bb, targets)
+          case Rook   => position.genRook(us & bb, targets)
+          case Queen  => position.genQueen(us & bb, targets)
+          case King   => position.genKingAt(targets, square)
+    }
+
   def pieceThreatened(board: Board, by: Color, to: Square): Boolean =
     board.attacks(to, by)
 


### PR DESCRIPTION
- Removes `Variant.finalizeBoard` as We only use it in `CrazyHouse` and `ThreeCheck` to update the corresponding history. We apply this history update right after generate moves in `Variant.validMoves` instead.
- Move `generateMovesAt` logic to variant, this keeps variant's specific effect/state private and independent.