### PR TITLE
Simplify Variant.move

### DIFF
--- a/core/src/main/scala/History.scala
+++ b/core/src/main/scala/History.scala
@@ -4,19 +4,6 @@ import chess.variant.Crazyhouse
 
 import format.Uci
 
-// Checks received by the respective side.
-case class CheckCount(white: Int = 0, black: Int = 0):
-
-  def add(color: Color) =
-    copy(
-      white = white + color.fold(1, 0),
-      black = black + color.fold(0, 1)
-    )
-
-  def nonEmpty = white > 0 || black > 0
-
-  def apply(color: Color) = color.fold(white, black)
-
 case class History(
     lastMove: Option[Uci] = None,
     positionHashes: PositionHash = PositionHash.empty,
@@ -49,3 +36,16 @@ case class History(
     if check.yes then copy(checkCount = checkCount.add(color)) else this
 
   def withCheckCount(cc: CheckCount): History = copy(checkCount = cc)
+
+// Checks received by the respective side.
+case class CheckCount(white: Int = 0, black: Int = 0):
+
+  def add(color: Color): CheckCount =
+    copy(
+      white = white + color.fold(1, 0),
+      black = black + color.fold(0, 1)
+    )
+
+  def apply(color: Color): Int = color.fold(white, black)
+
+  def nonEmpty: Boolean = white > 0 || black > 0

--- a/core/src/main/scala/MoveOrDrop.scala
+++ b/core/src/main/scala/MoveOrDrop.scala
@@ -123,17 +123,6 @@ case class Move(
   val isWhiteTurn: Boolean = piece.color.white
   inline def color         = piece.color
 
-  def withPromotion(op: Option[PromotableRole]): Option[Move] =
-    op.fold(this.some)(withPromotion)
-
-  def withPromotion(p: PromotableRole): Option[Move] =
-    if after.count(color.queen) > before.count(color.queen) then
-      for
-        b2 <- after.board.take(dest)
-        b3 <- b2.put(color - p, dest)
-      yield copy(after = after.withBoard(b3), promotion = Option(p))
-    else this.some
-
   inline def withMetrics(m: MoveMetrics): Move = copy(metrics = m)
 
   override lazy val toSanStr: SanStr = format.pgn.Dumper(this)

--- a/core/src/main/scala/format/pgn/parsingModel.scala
+++ b/core/src/main/scala/format/pgn/parsingModel.scala
@@ -79,10 +79,9 @@ case class Std(
       .byPiece(position.color, role)
       .first: square =>
         if compare(file, square.file) && compare(rank, square.rank)
-        then position.generateMovesAt(square).find(_.dest == dest)
+        then position.generateMovesAt(square).find(m => m.dest == dest && m.promotion == promotion)
         else None
       .toRight(ErrorStr(s"Cannot play $this"))
-      .flatMap(_.withPromotion(promotion).toRight(ErrorStr("Wrong promotion")))
 
   override def toString = s"$role ${dest.key}"
 

--- a/core/src/main/scala/variant/Crazyhouse.scala
+++ b/core/src/main/scala/variant/Crazyhouse.scala
@@ -41,18 +41,13 @@ case object Crazyhouse
       b1 <- position.board
         .put(piece, square)
         .toRight(ErrorStr(s"Can't drop $role on $square, it's occupied"))
-      b2 = position.withBoard(b1)
+      b2 = position.withBoard(b1).withCrazyData(d2)
       _ <- Either.cond(
         kingThreatened(b2.board, position.color).no,
         b2,
         ErrorStr(s"Dropping $role on $square doesn't uncheck the king")
       )
-    yield Drop(
-      piece = piece,
-      square = square,
-      before = position,
-      after = b2.withCrazyData(d2)
-    )
+    yield Drop(piece = piece, square = square, before = position, after = b2)
 
   override def fiftyMoves(history: History): Boolean = false
 

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -92,8 +92,8 @@ abstract class Variant private[variant] (
       promotion: Option[PromotableRole]
   ): Either[ErrorStr, Move] =
     // Find the move in the variant specific list of valid moves
-    def findMove(from: Square, to: Square) =
-      position.generateMovesAt(from).find(_.dest == to)
+    inline def findMove(from: Square, to: Square) =
+      validMovesAt(position, from).find(_.dest == to)
 
     for
       piece <- position.pieceAt(from).toRight(ErrorStr(s"No piece on ${from.key}"))

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -91,14 +91,9 @@ abstract class Variant private[variant] (
       to: Square,
       promotion: Option[PromotableRole]
   ): Either[ErrorStr, Move] =
-    // Find the move that matches the from, to and promotion
-    inline def findMove(from: Square, to: Square, promotion: Option[PromotableRole]): Option[Move] =
-      validMovesAt(position, from).find(m => m.dest == to && m.promotion == promotion)
-    for
-      piece <- position.pieceAt(from).toRight(ErrorStr(s"No piece on ${from.key}"))
-      _     <- Either.cond(piece.color == position.color, piece, ErrorStr(s"Not my piece on ${from.key}"))
-      m1 <- findMove(from, to, promotion).toRight(ErrorStr(s"Piece on ${from.key} cannot move to ${to.key}"))
-    yield m1
+    validMovesAt(position, from)
+      .find(m => m.dest == to && m.promotion == promotion)
+      .toRight(ErrorStr(s"Piece on ${from.key} cannot move to ${to.key}"))
 
   def drop(position: Position, role: Role, square: Square): Either[ErrorStr, Drop] =
     ErrorStr(s"$this variant cannot drop $role $square").asLeft

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -91,23 +91,14 @@ abstract class Variant private[variant] (
       to: Square,
       promotion: Option[PromotableRole]
   ): Either[ErrorStr, Move] =
-    // Find the move in the variant specific list of valid moves
-    inline def findMove(from: Square, to: Square) =
-      validMovesAt(position, from).find(_.dest == to)
-
+    // Find the move that matches the from, to and promotion
+    inline def findMove(from: Square, to: Square, promotion: Option[PromotableRole]): Option[Move] =
+      validMovesAt(position, from).find(m => m.dest == to && m.promotion == promotion)
     for
       piece <- position.pieceAt(from).toRight(ErrorStr(s"No piece on ${from.key}"))
       _     <- Either.cond(piece.color == position.color, piece, ErrorStr(s"Not my piece on ${from.key}"))
-      m1    <- findMove(from, to).toRight(ErrorStr(s"Piece on ${from.key} cannot move to ${to.key}"))
-      m2 <- m1
-        .withPromotion(promotion)
-        .toRight(ErrorStr(s"Piece on ${from.key} cannot promote to $promotion"))
-      m3 <- Either.cond(
-        isValidPromotion(promotion),
-        m2,
-        ErrorStr(s"Cannot promote to $promotion in this game mode")
-      )
-    yield m3
+      m1 <- findMove(from, to, promotion).toRight(ErrorStr(s"Piece on ${from.key} cannot move to ${to.key}"))
+    yield m1
 
   def drop(position: Position, role: Role, square: Square): Either[ErrorStr, Drop] =
     ErrorStr(s"$this variant cannot drop $role $square").asLeft

--- a/test-kit/src/test/scala/format/pgn/DumperTest.scala
+++ b/test-kit/src/test/scala/format/pgn/DumperTest.scala
@@ -109,7 +109,7 @@ PP   PPP
 KNBQ BNR
 """)
     game
-      .playMoves(A7 -> A8)
+      .playMove(A7, A8, Some(Queen))
       .map(_.sans)
       .assertRight: ms =>
         assertEquals(ms, Vector(SanStr("a8=Q")))
@@ -125,7 +125,7 @@ PP   PPP
 KNBQ BNR
 """)
     game
-      .playMoves(A7 -> A8)
+      .playMove(A7, A8, Some(Queen))
       .map(_.sans)
       .assertRight: ms =>
         assertEquals(ms, Vector(SanStr("a8=Q+")))
@@ -141,7 +141,7 @@ PP   PPP
 KNBQ BNR
 """)
     game
-      .playMoves(A7 -> A8)
+      .playMove(A7, A8, Some(Queen))
       .map(_.sans)
       .assertRight: ms =>
         assertEquals(ms, Vector(SanStr("a8=Q#")))


### PR DESCRIPTION
Remove all of unneeded checks and calculation in `Variant.move`. We can just find move that have same destination and promotion as input. This also removes the need of `Move.withPromotion`.