### PR TITLE
Add increment value to correspondence clock

### DIFF
--- a/core/src/main/scala/CorrespondenceClock.scala
+++ b/core/src/main/scala/CorrespondenceClock.scala
@@ -6,6 +6,7 @@ import java.time.Instant
 
 // times are expressed in seconds
 case class CorrespondenceClock(
+    base: Int,
     increment: Int,
     whiteTime: Float,
     blackTime: Float
@@ -27,7 +28,7 @@ case class CorrespondenceClock(
     )
 
   // in seconds
-  def estimateTotalTime: Int = increment * 40 / 2
+  def estimateTotalTime: Int = base + increment * 40 / 2
 
   def incrementHours: Int = increment / 60 / 60
 
@@ -35,11 +36,21 @@ object CorrespondenceClock:
   val hourSeconds = 60 * 60
   val daySeconds  = 24 * hourSeconds
 
-  def apply(daysPerTurn: Int, turnColor: Color, lastMoveAt: Instant): CorrespondenceClock =
-    val increment   = daysPerTurn * 24 * 60 * 60
+  // TODO: specify which color to add days to, if allowing addition to either color
+  def apply(
+      base: Int,
+      increment: Int,
+      remainingTime: Float,
+      daysToAdd: Int,
+      turnColor: Color,
+      lastMoveAt: Instant
+  ): CorrespondenceClock =
+    val limit       = base
+    val incremented = (remainingTime + (daysToAdd * daySeconds)).max(limit * daySeconds).toInt.max(0)
     val secondsLeft = (lastMoveAt.toSeconds + increment - nowSeconds).toInt.max(0)
     CorrespondenceClock(
+      base = base,
       increment = increment,
-      whiteTime = turnColor.fold(secondsLeft, increment).toFloat,
-      blackTime = turnColor.fold(increment, secondsLeft).toFloat
+      whiteTime = turnColor.fold(secondsLeft, incremented).toFloat,
+      blackTime = turnColor.fold(incremented, secondsLeft).toFloat
     )


### PR DESCRIPTION
Currently on Lichess correspondence is played at a pace of X days per move.  However, sometimes players cannot plan their lives around chess, and we do not offer vacation mode etc. like other correspondence chess sites.  Having an increment (with a limit - currently set to the base number of days) may allow for games to complete in under a year while still allowing players some flexibility when they can't play every day.

I have not tested this and I do not understand why clock times are represented as floating-point values.