### PR TITLE
Implement Canplay.{fold, foldRight}

### DIFF
--- a/bench/src/main/scala/benchmarks/PlayBench.scala
+++ b/bench/src/main/scala/benchmarks/PlayBench.scala
@@ -24,7 +24,6 @@ class PlayBench:
 
   var dividerGames: List[List[Board]] = scala.compiletime.uninitialized
   var gameMoves: List[List[SanStr]]   = scala.compiletime.uninitialized
-  var standard: Game                  = scala.compiletime.uninitialized
 
   def gameReplay(sans: String) =
     Standard.initialPosition.playBoards(SanStr.from(sans.split(' ')).toList).toOption.get
@@ -37,8 +36,6 @@ class PlayBench:
     var games = Fixtures.prod500standard
     gameMoves = games.take(nb).map(g => SanStr.from(g.split(' ').toList))
 
-    standard = Game(chess.variant.Standard.initialPosition)
-
   @Benchmark
   def divider(bh: Blackhole) =
     var result = dividerGames.map: x =>
@@ -48,59 +45,22 @@ class PlayBench:
     result
 
   @Benchmark
-  def replay(bh: Blackhole) =
-    var result = gameMoves.map: moves =>
+  def gameMoveWhileValid(bh: Blackhole) =
+    val games = this.gameMoves
+    var i     = 0
+    while i < games.size do
+      val moves = games(i)
       Blackhole.consumeCPU(Work)
-      Replay.gameMoveWhileValid(moves, chess.format.Fen.initial, chess.variant.Standard)
-    bh.consume(result)
-    result
+      bh.consume(Replay.gameMoveWhileValid(moves, chess.format.Fen.initial, chess.variant.Standard))
+      i += 1
 
   @Benchmark
-  def play(bh: Blackhole) =
-    var result = standard.playMoves(
-      bh,
-      E2 -> E4,
-      D7 -> D5,
-      E4 -> D5,
-      D8 -> D5,
-      B1 -> C3,
-      D5 -> A5,
-      D2 -> D4,
-      C7 -> C6,
-      G1 -> F3,
-      C8 -> G4,
-      C1 -> F4,
-      E7 -> E6,
-      H2 -> H3,
-      G4 -> F3,
-      D1 -> F3,
-      F8 -> B4,
-      F1 -> E2,
-      B8 -> D7,
-      A2 -> A3,
-      E8 -> C8,
-      A3 -> B4,
-      A5 -> A1,
-      E1 -> D2,
-      A1 -> H1,
-      F3 -> C6,
-      B7 -> C6,
-      E2 -> A6
-    )
-    bh.consume(result)
-    result
-
-  extension (game: Game)
-    def as(color: Color): Game = game.withPlayer(color)
-
-    def playMoves(bh: Blackhole, moves: (Square, Square)*): Either[ErrorStr, Game] = playMoveList(bh, moves)
-
-    def playMoveList(bh: Blackhole, moves: Iterable[(Square, Square)]): Either[ErrorStr, Game] =
-      moves.toList.foldM(game):
-        case (game, (o, d)) =>
-          // because possible moves are asked for player highlight
-          // before the move is played (on initial board)
-          Blackhole.consumeCPU(Work)
-          var result = game.position.destinations
-          bh.consume(result)
-          game(o, d).map(_._1)
+  def playMoveOrDropWithPly(bh: Blackhole) =
+    val games = this.gameMoves
+    var i     = 0
+    while i < games.size do
+      val moves = games(i)
+      Blackhole.consumeCPU(Work)
+      val init = chess.Position.AndFullMoveNumber(chess.variant.Standard, chess.format.Fen.initial.some)
+      bh.consume(init.position.play(moves, init.ply)(step => chess.MoveOrDrop.WithPly(step.move, step.ply)))
+      i += 1

--- a/core/src/main/scala/CanPlay.scala
+++ b/core/src/main/scala/CanPlay.scala
@@ -40,6 +40,12 @@ trait CanPlay[A]:
     def play[F[_]: Traverse](moves: F[SanStr]): Either[ErrorStr, List[MoveOrDrop]] =
       Parser.moves(moves).flatMap(play)
 
+    @targetName("playFromSans")
+    def play[F[_]: Traverse](moves: F[SanStr], initialPly: Ply)[B](
+        transform: Step => B
+    ): Either[ErrorStr, List[B]] =
+      Parser.moves(moves).flatMap(xs => play(xs, initialPly)(transform))
+
     def play[M <: Moveable, F[_]: Traverse](moves: F[M], initialPly: Ply)[B](
         transform: Step => B
     ): Either[ErrorStr, List[B]] =

--- a/core/src/main/scala/MoveOrDrop.scala
+++ b/core/src/main/scala/MoveOrDrop.scala
@@ -31,6 +31,11 @@ sealed trait MoveOrDrop:
       case m: Move => game(m)
       case d: Drop => game.applyDrop(d)
 
+object MoveOrDrop:
+
+  case class WithPly(moveOrDrop: MoveOrDrop, ply: Ply):
+    export moveOrDrop.*
+
 case class Move(
     piece: Piece,
     orig: Square,

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -13,7 +13,7 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
   export history.{ castles, unmovedRooks, crazyData }
   // format: off
   export board.{ attackers, attacks, bishops, black, byColor, byPiece, byRole, byRoleOf, colorAt,
-    fold, foreach, isCheck, isOccupied, kingOf, kingPosOf, kings, kingsAndBishopsOnly,
+    foreach, isCheck, isOccupied, kingOf, kingPosOf, kings, kingsAndBishopsOnly,
     kingsAndBishopsOnlyOf, kingsAndKnightsOnly, kingsAndKnightsOnlyOf, kingsAndMinorsOnly,
     kingsOnly, kingsOnlyOf, kingsRooksAndMinorsOnly, knights, nbPieces, nonKingsOf, occupied,
     onlyKnights, onlyOf, pawns, piece, pieceAt, pieceMap as pieces, pieces as allPieces, piecesOf,

--- a/core/src/main/scala/Replay.scala
+++ b/core/src/main/scala/Replay.scala
@@ -29,7 +29,7 @@ object Replay:
       initialFen: Fen.Full,
       variant: Variant
   ): (Game, List[(Game, Uci.WithSan)], Option[ErrorStr]) =
-    inline def transform(success: (next: Game, move: MoveOrDrop)) =
+    inline def transform(success: (next: Game, move: MoveOrDrop, ply: Ply)) =
       (success.next, Uci.WithSan(success.move.toUci, success.move.toSanStr))
     val init = Game(variant, initialFen.some)
     init

--- a/test-kit/src/test/scala/CanPlayTest.scala
+++ b/test-kit/src/test/scala/CanPlayTest.scala
@@ -55,6 +55,21 @@ class CanPlayTest extends MunitExtensions with SnapshotAssertions:
     assertEquals(x.error, y.error)
     assertEquals(x.state.board, y.state.board)
 
+  test("refold has correct plies"):
+    val sans = SanStr.from(Fixtures.fromProd2.split(' ').toList)
+    val x    = Standard.initialPosition
+      .refold(sans, Ply.initial)(List.empty[Ply], (xs, step) => step.ply :: xs)
+      .toOption
+      .get
+    val y = Standard.initialPosition
+      .refoldRight(sans, Ply.initial)(List.empty[Ply], (step, xs) => step.ply :: xs)
+      .toOption
+      .get
+    assertEquals(y.result(0), Ply.initial.next)
+    assertEquals(x.result, y.result.reverse)
+    assertEquals(x.error, None)
+    assertEquals(y.error, None)
+
   /*============== Error Messages ==============*/
 
   test("error message for white"):

--- a/test-kit/src/test/scala/CanPlayTest.scala
+++ b/test-kit/src/test/scala/CanPlayTest.scala
@@ -55,14 +55,14 @@ class CanPlayTest extends MunitExtensions with SnapshotAssertions:
     assertEquals(x.error, y.error)
     assertEquals(x.state.board, y.state.board)
 
-  test("refold has correct plies"):
+  test("fold has correct plies"):
     val sans = SanStr.from(Fixtures.fromProd2.split(' ').toList)
     val x    = Standard.initialPosition
-      .refold(sans, Ply.initial)(List.empty[Ply], (xs, step) => step.ply :: xs)
+      .fold(sans, Ply.initial)(List.empty[Ply], (xs, step) => step.ply :: xs)
       .toOption
       .get
     val y = Standard.initialPosition
-      .refoldRight(sans, Ply.initial)(List.empty[Ply], (step, xs) => step.ply :: xs)
+      .foldRight(sans, Ply.initial)(List.empty[Ply], (step, xs) => step.ply :: xs)
       .toOption
       .get
     assertEquals(y.result(0), Ply.initial.next)


### PR DESCRIPTION
With `CanPlay{fold, foldRight}` We can replay (parse) moves and combine result into one value. This is helpful for creating `lila.tree.Root` from a game and analysis.

- **Implement Canplay.{fold, foldRight}**
- **Add Canplay.play with sans**
- **Add MoveOrDrop.WithPly**
- **Implement benchmarks**