### PR TITLE
fix deadlock class initialization

### DIFF
--- a/core/src/main/scala/Board.scala
+++ b/core/src/main/scala/Board.scala
@@ -294,6 +294,21 @@ object Board:
     ByRole.fill(Bitboard.empty)
   )
 
+  val standard = Board(
+    occupied = Bitboard(0xffff00000000ffffL),
+    byColor = ByColor(
+      white = Bitboard(0x000000000000ffffL),
+      black = Bitboard(0xffff000000000000L)
+    ),
+    byRole = ByRole(
+      pawn = Bitboard(0x00ff00000000ff00L),
+      knight = Bitboard(0x4200000000000042L),
+      bishop = Bitboard(0x2400000000000024L),
+      rook = Bitboard(0x8100000000000081L),
+      queen = Bitboard(0x0800000000000008L),
+      king = Bitboard(0x1000000000000010L)
+    )
+  )
   def fromMap(pieces: PieceMap): Board =
     var pawns    = Bitboard.empty
     var knights  = Bitboard.empty

--- a/core/src/main/scala/variant/Antichess.scala
+++ b/core/src/main/scala/variant/Antichess.scala
@@ -14,8 +14,8 @@ case object Antichess
       standardInitialPosition = true
     ):
 
-  override val initialPieces: Map[Square, Piece] = Standard.initialPieces
-  override val initialBoard: Board               = Board.fromMap(initialPieces)
+  override def initialPieces: Map[Square, Piece] = Standard.initialPieces
+  override val initialBoard: Board               = Board.standard
 
   // In antichess, it is not permitted to castle
   override val castles: Castles    = Castles.none

--- a/core/src/main/scala/variant/Antichess.scala
+++ b/core/src/main/scala/variant/Antichess.scala
@@ -14,8 +14,8 @@ case object Antichess
       standardInitialPosition = true
     ):
 
-  override def initialPieces: Map[Square, Piece] = Standard.initialPieces
   override val initialBoard: Board               = Board.standard
+  override def initialPieces: Map[Square, Piece] = initialBoard.pieceMap
 
   // In antichess, it is not permitted to castle
   override val castles: Castles    = Castles.none

--- a/core/src/main/scala/variant/Atomic.scala
+++ b/core/src/main/scala/variant/Atomic.scala
@@ -12,8 +12,8 @@ case object Atomic
       standardInitialPosition = true
     ):
 
-  override val initialPieces: Map[Square, Piece] = Standard.initialPieces
-  override val initialBoard: Board               = Board.fromMap(initialPieces)
+  override def initialPieces: Map[Square, Piece] = Standard.initialPieces
+  override val initialBoard: Board               = Board.standard
 
   override def validMoves(position: Position): List[Move] =
     import position.{ genNonKing, genEnPassant, us }

--- a/core/src/main/scala/variant/Atomic.scala
+++ b/core/src/main/scala/variant/Atomic.scala
@@ -12,8 +12,8 @@ case object Atomic
       standardInitialPosition = true
     ):
 
-  override def initialPieces: Map[Square, Piece] = Standard.initialPieces
   override val initialBoard: Board               = Board.standard
+  override def initialPieces: Map[Square, Piece] = initialBoard.pieceMap
 
   override def validMoves(position: Position): List[Move] =
     import position.{ genNonKing, genEnPassant, us }

--- a/core/src/main/scala/variant/Crazyhouse.scala
+++ b/core/src/main/scala/variant/Crazyhouse.scala
@@ -15,8 +15,8 @@ case object Crazyhouse
       standardInitialPosition = true
     ):
 
-  override val initialPieces: Map[Square, Piece] = Standard.initialPieces
-  override val initialBoard: Board               = Board.fromMap(initialPieces)
+  override def initialPieces: Map[Square, Piece] = Standard.initialPieces
+  override val initialBoard: Board               = Board.standard
 
   override val initialFen: FullFen = FullFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR/ w KQkq - 0 1")
 

--- a/core/src/main/scala/variant/Crazyhouse.scala
+++ b/core/src/main/scala/variant/Crazyhouse.scala
@@ -15,8 +15,8 @@ case object Crazyhouse
       standardInitialPosition = true
     ):
 
-  override def initialPieces: Map[Square, Piece] = Standard.initialPieces
   override val initialBoard: Board               = Board.standard
+  override def initialPieces: Map[Square, Piece] = initialBoard.pieceMap
 
   override val initialFen: FullFen = FullFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR/ w KQkq - 0 1")
 

--- a/core/src/main/scala/variant/FromPosition.scala
+++ b/core/src/main/scala/variant/FromPosition.scala
@@ -12,8 +12,8 @@ case object FromPosition
       standardInitialPosition = false
     ):
 
-  override val initialPieces: Map[Square, Piece] = Standard.initialPieces
-  override val initialBoard: Board               = Board.fromMap(initialPieces)
+  override val initialBoard: Board               = Board.standard
+  override def initialPieces: Map[Square, Piece] = initialBoard.pieceMap
 
   override def validMoves(position: Position): List[Move] =
     Standard.validMoves(position)

--- a/core/src/main/scala/variant/KingOfTheHill.scala
+++ b/core/src/main/scala/variant/KingOfTheHill.scala
@@ -12,8 +12,8 @@ case object KingOfTheHill
       standardInitialPosition = true
     ):
 
-  override val initialPieces: Map[Square, Piece] = Standard.initialPieces
-  override val initialBoard: Board               = Board.fromMap(initialPieces)
+  override def initialPieces: Map[Square, Piece] = Standard.initialPieces
+  override val initialBoard: Board               = Board.standard
 
   override def validMoves(position: Position): List[Move] =
     Standard.validMoves(position)

--- a/core/src/main/scala/variant/KingOfTheHill.scala
+++ b/core/src/main/scala/variant/KingOfTheHill.scala
@@ -12,8 +12,8 @@ case object KingOfTheHill
       standardInitialPosition = true
     ):
 
-  override def initialPieces: Map[Square, Piece] = Standard.initialPieces
   override val initialBoard: Board               = Board.standard
+  override def initialPieces: Map[Square, Piece] = initialBoard.pieceMap
 
   override def validMoves(position: Position): List[Move] =
     Standard.validMoves(position)

--- a/core/src/main/scala/variant/Standard.scala
+++ b/core/src/main/scala/variant/Standard.scala
@@ -12,8 +12,8 @@ case object Standard
       standardInitialPosition = true
     ):
 
-  override def initialPieces: Map[Square, Piece] = Variant.symmetricRank(backRank)
   override val initialBoard: Board               = Board.standard
+  override def initialPieces: Map[Square, Piece] = initialBoard.pieceMap
   override val initialPosition: Position         = Position(initialBoard, this, White)
 
   override def valid(position: Position, strict: Boolean): Boolean =

--- a/core/src/main/scala/variant/Standard.scala
+++ b/core/src/main/scala/variant/Standard.scala
@@ -12,8 +12,8 @@ case object Standard
       standardInitialPosition = true
     ):
 
-  override val initialPieces: Map[Square, Piece] = Variant.symmetricRank(backRank)
-  override val initialBoard: Board               = Board.fromMap(initialPieces)
+  override def initialPieces: Map[Square, Piece] = Variant.symmetricRank(backRank)
+  override val initialBoard: Board               = Board.standard
   override val initialPosition: Position         = Position(initialBoard, this, White)
 
   override def valid(position: Position, strict: Boolean): Boolean =

--- a/core/src/main/scala/variant/ThreeCheck.scala
+++ b/core/src/main/scala/variant/ThreeCheck.scala
@@ -14,8 +14,8 @@ case object ThreeCheck
       standardInitialPosition = true
     ):
 
-  override def initialPieces: Map[Square, Piece] = Standard.initialPieces
   override val initialBoard: Board               = Board.standard
+  override def initialPieces: Map[Square, Piece] = initialBoard.pieceMap
 
   override val initialFen: FullFen = FullFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 +0+0")
 

--- a/core/src/main/scala/variant/ThreeCheck.scala
+++ b/core/src/main/scala/variant/ThreeCheck.scala
@@ -14,8 +14,8 @@ case object ThreeCheck
       standardInitialPosition = true
     ):
 
-  override val initialPieces: Map[Square, Piece] = Standard.initialPieces
-  override val initialBoard: Board               = Board.fromMap(initialPieces)
+  override def initialPieces: Map[Square, Piece] = Standard.initialPieces
+  override val initialBoard: Board               = Board.standard
 
   override val initialFen: FullFen = FullFen("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 +0+0")
 


### PR DESCRIPTION
We started to use `Standard` more when initialize other object
especially with `Standard.initialPosition`. This increases the chances
of deadlock when initializing classes. Locally it happen 50% of times I
run test. This commit is to reducing computation time when initialize
Standard, and also reducing reference of Standard from other variants.

- Use hard-coded initial Board for standard position
- Move initialPieces to def
- Derive initialPieces from initialBoard
