### PR TITLE
Bump scalachess version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import snapshot4s.BuildInfo.snapshot4sVersion
 inThisBuild(
   Seq(
     scalaVersion := "3.7.1",
-    version := "17.9.1",
+    version := "17.9.2",
     organization := "com.github.lichess-org.scalachess",
     licenses += ("MIT" -> url("https://opensource.org/licenses/MIT")),
     publishTo := Option(Resolver.file("file", new File(sys.props.getOrElse("publishTo", "")))),


### PR DESCRIPTION
Just to use the new status code in [#17666](https://github.com/lichess-org/lila/pull/17666).