### PR TITLE
Forced insufficient material

### DIFF
--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -88,6 +88,7 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
     variant.opponentHasInsufficientMaterial(this) ||
       (
         legalMoves.nonEmpty &&
+          drops.forall(_.isEmpty) &&
           legalMoves.sortBy(_.captures).forall { move =>
             val newPos = move.after
             val winner = newPos.winner

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -88,7 +88,13 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
     variant.opponentHasInsufficientMaterial(this) ||
       (
         legalMoves.nonEmpty &&
-          legalMoves.forall(_.after.playerHasInsufficientMaterial)
+          legalMoves.sortBy(_.captures).forall { move =>
+            val newPos = move.after
+            val winner = newPos.winner
+            winner == Some(color) ||
+            newPos.playerHasInsufficientMaterial ||
+            (newPos.staleMate && winner != Some(!color))
+          }
       )
 
   inline def playerHasInsufficientMaterial: Boolean = variant.playerHasInsufficientMaterial(this)

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -84,7 +84,12 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
 
   inline def autoDraw: Boolean = variant.autoDraw(this) || variant.specialDraw(this)
 
-  inline def opponentHasInsufficientMaterial: Boolean = variant.opponentHasInsufficientMaterial(this)
+  inline def opponentHasInsufficientMaterial: Boolean =
+    variant.opponentHasInsufficientMaterial(this) ||
+      (
+        legalMoves.nonEmpty &&
+          legalMoves.forall(_.after.playerHasInsufficientMaterial)
+      )
 
   inline def playerHasInsufficientMaterial: Boolean = variant.playerHasInsufficientMaterial(this)
 

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -92,9 +92,11 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
           legalMoves.sortBy(_.captures).forall { move =>
             val newPos = move.after
             val winner = newPos.winner
-            winner == Some(color) ||
-            newPos.playerHasInsufficientMaterial ||
-            (newPos.staleMate && winner != Some(!color))
+            winner != Some(!color) && (
+              winner == Some(color) ||
+                newPos.playerHasInsufficientMaterial ||
+                newPos.staleMate
+            )
           }
       )
 

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -93,9 +93,11 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
           legalMoves.sortBy(_.captures).forall { move =>
             val newPos = move.after
             val winner = newPos.winner
-            winner == Some(color) ||
-            newPos.playerHasInsufficientMaterial ||
-            (newPos.staleMate && winner != Some(!color))
+            winner != Some(!color) && (
+              winner == Some(color) ||
+                newPos.playerHasInsufficientMaterial ||
+                newPos.staleMate
+            )
           }
       )
 

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -89,6 +89,7 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
     variant.opponentHasInsufficientMaterial(this) ||
       (
         legalMoves.nonEmpty &&
+          drops.forall(_.isEmpty) &&
           legalMoves.sortBy(_.captures).forall { move =>
             val newPos = move.after
             val winner = newPos.winner

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -85,7 +85,12 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
 
   inline def autoDraw: Boolean = variant.autoDraw(this) || variant.specialDraw(this)
 
-  inline def opponentHasInsufficientMaterial: Boolean = variant.opponentHasInsufficientMaterial(this)
+  inline def opponentHasInsufficientMaterial: Boolean =
+    variant.opponentHasInsufficientMaterial(this) ||
+      (
+        legalMoves.nonEmpty &&
+          legalMoves.forall(_.after.playerHasInsufficientMaterial)
+      )
 
   inline def playerHasInsufficientMaterial: Boolean = variant.playerHasInsufficientMaterial(this)
 

--- a/core/src/main/scala/Position.scala
+++ b/core/src/main/scala/Position.scala
@@ -89,7 +89,13 @@ case class Position(board: Board, history: History, variant: Variant, color: Col
     variant.opponentHasInsufficientMaterial(this) ||
       (
         legalMoves.nonEmpty &&
-          legalMoves.forall(_.after.playerHasInsufficientMaterial)
+          legalMoves.sortBy(_.captures).forall { move =>
+            val newPos = move.after
+            val winner = newPos.winner
+            winner == Some(color) ||
+            newPos.playerHasInsufficientMaterial ||
+            (newPos.staleMate && winner != Some(!color))
+          }
       )
 
   inline def playerHasInsufficientMaterial: Boolean = variant.playerHasInsufficientMaterial(this)

--- a/core/src/main/scala/variant/Atomic.scala
+++ b/core/src/main/scala/variant/Atomic.scala
@@ -30,6 +30,9 @@ case object Atomic
   override def opponentHasInsufficientMaterial(position: Position) =
     position.kingsOnlyOf(!position.color)
 
+  override def playerHasInsufficientMaterial(position: Position) =
+    position.kingsOnlyOf(position.color)
+
   /** Atomic chess has a special end where a king has been killed by exploding with an adjacent captured piece */
   override def specialEnd(position: Position): Boolean = position.kings.count < 2
   override def validMovesAt(position: Position, square: Square): List[Move] =

--- a/core/src/main/scala/variant/Crazyhouse.scala
+++ b/core/src/main/scala/variant/Crazyhouse.scala
@@ -62,6 +62,7 @@ case object Crazyhouse
 
   // there is always sufficient mating material in Crazyhouse
   override def opponentHasInsufficientMaterial(position: Position): Boolean = false
+  override def playerHasInsufficientMaterial(position: Position): Boolean = false
   override def isInsufficientMaterial(position: Position): Boolean = false
 
   // if the king is not in check, all drops are possible, we just return None

--- a/core/src/main/scala/variant/KingOfTheHill.scala
+++ b/core/src/main/scala/variant/KingOfTheHill.scala
@@ -30,4 +30,5 @@ case object KingOfTheHill
   /** You only need a king to be able to win in this variant
     */
   override def opponentHasInsufficientMaterial(position: Position): Boolean = false
+  override def playerHasInsufficientMaterial(position: Position): Boolean = false
   override def isInsufficientMaterial(position: Position): Boolean = false

--- a/core/src/main/scala/variant/RacingKings.scala
+++ b/core/src/main/scala/variant/RacingKings.scala
@@ -55,6 +55,7 @@ case object RacingKings
 
   override def isInsufficientMaterial(position: Position): Boolean = false
   override def opponentHasInsufficientMaterial(position: Position): Boolean = false
+  override def playerHasInsufficientMaterial(position: Position): Boolean = false
 
   // It is a win, when exactly one king made it to the goal. When white reaches
   // the goal and black can make it on the next ply, he is given a chance to

--- a/core/src/main/scala/variant/RacingKings.scala
+++ b/core/src/main/scala/variant/RacingKings.scala
@@ -58,6 +58,7 @@ case object RacingKings
 
   override def isInsufficientMaterial(position: Position): Boolean = false
   override def opponentHasInsufficientMaterial(position: Position): Boolean = false
+  override def playerHasInsufficientMaterial(position: Position): Boolean = false
 
   // It is a win, when exactly one king made it to the goal. When white reaches
   // the goal and black can make it on the next ply, he is given a chance to

--- a/core/src/main/scala/variant/ThreeCheck.scala
+++ b/core/src/main/scala/variant/ThreeCheck.scala
@@ -38,6 +38,9 @@ case object ThreeCheck
   override def opponentHasInsufficientMaterial(position: Position): Boolean =
     position.kingsOnlyOf(!position.color)
 
+  override def playerHasInsufficientMaterial(position: Position): Boolean =
+    position.kingsOnlyOf(position.color)
+
   /**
   * When there is insufficient mating material, there is still potential to win by checking the opponent 3 times
   * by the variant ending. However, no players can check if there are only kings remaining

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -154,8 +154,7 @@ abstract class Variant private[variant] (
     InsufficientMatingMaterial(position.board, !position.color)
 
   def playerHasInsufficientMaterial(position: Position): Boolean =
-    // For all variants except Antichess and Horde, considering turn isn't needed:
-    opponentHasInsufficientMaterial(position.withColor(!position.color))
+    InsufficientMatingMaterial(position.board, position.color)
 
   def fiftyMoves(history: History): Boolean =
     history.halfMoveClock >= HalfMoveClock(100)

--- a/core/src/main/scala/variant/Variant.scala
+++ b/core/src/main/scala/variant/Variant.scala
@@ -167,8 +167,7 @@ abstract class Variant private[variant] (
     InsufficientMatingMaterial(position.board, !position.color)
 
   def playerHasInsufficientMaterial(position: Position): Boolean =
-    // For all variants except Antichess and Horde, considering turn isn't needed:
-    opponentHasInsufficientMaterial(position.withColor(!position.color))
+    InsufficientMatingMaterial(position.board, position.color)
 
   def fiftyMoves(history: History): Boolean =
     history.halfMoveClock >= HalfMoveClock(100)

--- a/test-kit/src/test/scala/AntichessVariantTest.scala
+++ b/test-kit/src/test/scala/AntichessVariantTest.scala
@@ -208,6 +208,20 @@ g4 {[%emt 0.200]} 34. Rxg4 {[%emt 0.172]} 0-1"""
     val game = fenToGame(position, Antichess).playMoves(Square.H1 -> Square.G3).get
     assertEquals(game.position.playerHasInsufficientMaterial, false)
 
+  test(
+    "Opponent has sufficient material when player's only move leads to the former winning"
+  ):
+    val position = FullFen("8/7p/8/8/7P/8/8/8 b - - 0 1")
+    val game = fenToGame(position, Antichess).playMoves(Square.H7 -> Square.H6).get
+    assertEquals(game.position.opponentHasInsufficientMaterial, false)
+
+  test(
+    "Opponent has insufficient material when player's only move leads to the former having insufficient material"
+  ):
+    val position = FullFen("8/6p1/3n4/8/7N/8/8/8 b - - 0 1")
+    val game = fenToGame(position, Antichess).playMoves(Square.G7 -> Square.G6).get
+    assertEquals(game.position.opponentHasInsufficientMaterial, true)
+
   test("Not be drawn on insufficient mating material"):
     val position = FullFen("4K3/8/1b6/8/8/8/5B2/3k4 b - -")
     val game = fenToGame(position, Antichess)

--- a/test-kit/src/test/scala/CrazyhouseVariantTest.scala
+++ b/test-kit/src/test/scala/CrazyhouseVariantTest.scala
@@ -265,6 +265,30 @@ class CrazyhouseVariantTest extends ChessTest:
     assertNot(game.position.end)
     assertNot(game.position.opponentHasInsufficientMaterial)
 
+  test("insufficient mating material: not draw when drop possible for player"):
+    assertNot(
+      fenToGame(
+        FullFen("7k/5P1p/5PBR/5B1R/8/8/4K3/8/N w - - 0 1"),
+        Crazyhouse
+      ).position.opponentHasInsufficientMaterial
+    )
+
+  test("insufficient mating material: not draw when opponent's drop prevents stalemate"):
+    assertNot(
+      fenToGame(
+        FullFen("8/5B1k/5B1p/6KP/8/8/8/8/q w - - 0 1"),
+        Crazyhouse
+      ).position.opponentHasInsufficientMaterial
+    )
+
+  test("insufficient mating material: draw when stalemate on next move guaranteed"):
+    assert(
+      fenToGame(
+        FullFen("8/5B1k/5B1p/6KP/8/8/8/8/N w - - 0 1"),
+        Crazyhouse
+      ).position.opponentHasInsufficientMaterial
+    )
+
   test("destinations prod bug on game VVXRgsQT"):
     assertEquals(
       chess

--- a/test-kit/src/test/scala/VariantTest.scala
+++ b/test-kit/src/test/scala/VariantTest.scala
@@ -139,7 +139,7 @@ class VariantTest extends ChessTest:
     assertEquals(game.position.materialImbalance, -91)
     assert(game.position.opponentHasInsufficientMaterial)
 
-  test("standard Identify sufficient mating material when called (bishop)."):
+  test("standard Do not identify insufficient mating material when called (bishop)."):
     val position = FullFen("8/7B/K7/2b5/1k6/8/8/8 b - -")
     val game = fenToGame(position, Standard)
     assertEquals(game.position.materialImbalance, 0)
@@ -150,6 +150,32 @@ class VariantTest extends ChessTest:
     val game = fenToGame(position, Standard)
     assertEquals(game.position.materialImbalance, -6)
     assert(game.position.opponentHasInsufficientMaterial)
+
+  List(
+    "2kQ4/8/2K5/8/8/8/8/8 b - - 0 1",
+    "2kQ4/8/2K5/2N5/8/8/8/8 b - - 0 1",
+    "2kQ4/8/2K5/2B5/8/8/8/8 b - - 0 1",
+    "1bkQ4/8/2K5/8/8/8/8/8 b - - 0 1",
+    "n1kQ4/8/2K5/8/8/8/8/8 b - - 0 1",
+    "5Q1k/4b3/7K/3r4/7n/8/7P/8 b - - 0 1",
+    "7k/5Q1p/7P/8/8/8/1q4R1/K7 w - - 0 1"
+  ).foreach: fen =>
+    test("standard Identify insufficient mating material when only move(s) lead to at least a draw"):
+      assert(fenToGame(FullFen(fen), Standard).position.opponentHasInsufficientMaterial)
+
+  List(
+    "2kQ4/8/8/2K5/8/8/8/8 b - - 0 1",
+    "K2kr3/P3Q3/8/8/8/8/1r6/8 b - - 0 1"
+  ).foreach: fen =>
+    test(
+      "standard Do not identify insufficient mating material when some move doesn't lead to at least a draw"
+    ):
+      assertNot(fenToGame(FullFen(fen), Standard).position.opponentHasInsufficientMaterial)
+
+  test("standard Do not identify insufficient mating material in stalemates"):
+    assertNot(
+      fenToGame(FullFen("k7/2Q5/8/2K5/8/8/8/8 b - - 0 1"), Standard).position.opponentHasInsufficientMaterial
+    )
 
   test("chess960 position pieces correctly"):
     assertEquals(Chess960.initialPieces.get(A2), Some(White - Pawn))


### PR DESCRIPTION
From the FIDE handbook:

> The game is drawn when a position is reached from which a checkmate cannot occur by
any possible series of legal moves. This immediately ends the game, provided that the
move producing this position was legal.

If all of a player's legal moves reach a position where the opponent cannot win, then in the current position the opponent should be considered to have insufficient mating material. E.g., for [this](https://lichess.org/editor/6Rk/8/7K/8/8/8/8/8_b_-_-_0_1?color=white) example, this PR would make the game be declared drawn if Black ran out of time.

Note that the changes made in the `variant` subfolder (commit f689821) are not strictly needed, but it's less confusing to now not have turn-agnostic logic anywhere.