### PR TITLE
Fix statuses classified as having a winner

### DIFF
--- a/core/src/main/scala/Status.scala
+++ b/core/src/main/scala/Status.scala
@@ -39,7 +39,7 @@ object Status:
     s.id >= Mate.id && s.id != Cheat.id
   }
 
-  val finishedWithWinner = List(Mate, Resign, Timeout, Outoftime, Cheat, NoStart, VariantEnd)
+  val finishedWithWinner = List(Mate, Resign, Cheat, VariantEnd)
 
   val byId = all.mapBy(_.id)
 

--- a/test-kit/src/test/scala/StatusTest.scala
+++ b/test-kit/src/test/scala/StatusTest.scala
@@ -1,0 +1,11 @@
+package chess
+
+import munit.FunSuite
+
+class StatusTest extends FunSuite:
+
+  test("finished with winner"):
+    assertEquals(
+      Status.finishedWithWinner,
+      List(Status.Mate, Status.Resign, Status.Cheat, Status.VariantEnd)
+    )


### PR DESCRIPTION
Remove `Timeout`, `Outoftime`, and `NoStart` from `finishedWithWinner`, since each can finish without a winner. Add a regression test for the corrected set.

Closes #706.

Tests: left to CI.

AI disclosure: Codex helped identify the issue and draft the change and test. I reviewed and directed the work throughout as the human in the loop.